### PR TITLE
Fix OpenAPIの扱い修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,6 @@
 
 .idea
 lsp
-.ash_historycoverage
 coverage
 .ash_history
+.irb_history

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,10 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'
 
+Rails/RakeEnvironment:
+  Exclude:
+    - 'lib/tasks/development/fetch_openapi.rake'
+
 RSpec/NestedGroups:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,11 @@
 
 ## ホームケアナビ作成用PJ(API)
 
-### ディレクトリ構成
-<pre>
-── homeCareNavi_2nd
-    ├── homeCareNavi_2nd_API
-    ├── homeCareNavi_2nd_FRONT
-    └── homeCareNavi_2nd_OpenAPI
-</pre>
-
 ### 環境構築
-1. 全てのリポジトリの親となるディレクトリを作成する　例: `mkdir homeCareNavi_2nd`
-2. 作成したディレクトリに移動する　`cd homeCareNavi_2nd`
-3. OpenAPIリポジトリをクローンする　`git clone https://github.com/rahhi555/homeCareNavi_2nd_OpenAPI.git`
-4. FRONTリポジトリをクローンする　`https://github.com/rtkjm22/homeCareNavi_2nd_FRONT.git`
-5. APIリポジトリをクローンする　`https://github.com/rtkjm22/homeCareNavi_2nd_API.git`
-6. クローンしたAPIリポジトリに移動する　`cd homeCareNavi_2nd_API`
-7. compose.ymlを元に、dockerのdbイメージ及びapiイメージを立ち上げる　`docker compose build`
-8. 作成したイメージを元に、dockerコンテナを作成及び起動する　`dokcer compose up -d`
+1. APIリポジトリをクローンする　`https://github.com/rtkjm22/homeCareNavi_2nd_API.git`
+2. クローンしたAPIリポジトリに移動する　`cd homeCareNavi_2nd_API`
+3. compose.ymlを元に、dockerのdbイメージ及びapiイメージを立ち上げる　`docker compose build`
+4. 作成したイメージを元に、dockerコンテナを作成及び起動する　`dokcer compose up -d`
 
 #### 以下をアドレスバーに打ち込んで、{ message: 'API Health Check OK' } が返ってくればOK
 - http://localhost:3000/health_check
@@ -34,7 +22,8 @@
 `docker compose ps` | 起動中のコンテナを確認する
 `docker compose logs api` | apiコンテナのログを確認する。追従するには-fフラグ。ログが多い場合は--tail 100で直近100行目から開始
 
-
+#### githubから最新のopenapiを取得
+- `rake development:fetch_openapi`
 
 #### 詳細情報
 

--- a/compose.yml
+++ b/compose.yml
@@ -17,7 +17,6 @@ services:
     container_name: home-care-navi-second-api-container
     volumes:
       - .:/api
-      - ../homeCareNavi_2nd_OpenAPI/reference:/reference
     depends_on:
       - db
     ports:

--- a/home-care-navi-second-open-api.yaml
+++ b/home-care-navi-second-open-api.yaml
@@ -1,0 +1,872 @@
+openapi: 3.0.3
+x-stoplight:
+  id: oyf2pt1k0zz67
+info:
+  title: home-care-navi-second
+  version: '1.0'
+  description: 2期のホームケアナビのAPI仕様書
+  contact:
+    name: 平林直樹
+    url: 'https://example.com'
+    email: test@example.com
+  license:
+    name: MIT
+    url: 'https://example.com'
+  termsOfService: hogehgoe@example.com
+servers:
+  - url: 'http://localhost:3000'
+    description: 平林直樹
+paths:
+  /health_check:
+    get:
+      summary: ヘルスチェック
+      tags:
+        - health_check
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  message:
+                    type: string
+                    example: API Health Check OK
+                    description: メッセージに意味は無し
+                required:
+                  - message
+      operationId: getHealthCheck
+      description: ECSのヘルスチェック用エンドポイント
+  /api/v1/auth:
+    post:
+      summary: ユーザー新規作成
+      operationId: signUp
+      description: ユーザーを新規登録する。typeの値によって、ユーザーの種別(事務所利用者等)が決定する。
+      requestBody:
+        $ref: '#/components/requestBodies/Registration'
+      responses:
+        '200':
+          $ref: '#/components/responses/AuthSuccess'
+        '422':
+          $ref: '#/components/responses/Error'
+      tags:
+        - auth
+    parameters: []
+    patch:
+      summary: 登録者情報更新
+      operationId: updateAuth
+      responses:
+        '200':
+          description: OK
+      tags:
+        - auth
+      description: 登録者情報を更新する
+    delete:
+      summary: 退会
+      operationId: deleteAuth
+      responses:
+        '200':
+          description: OK
+      tags:
+        - auth
+      description: 退会する
+  /api/v1/auth/validate_token:
+    get:
+      summary: トークン検証
+      operationId: validateToken
+      description: 'ヘッダー内のaccess-token,client,expiry,uidを検証する'
+      parameters: []
+      security:
+        - access-token: []
+        - client: []
+        - expiry: []
+        - uid: []
+      responses:
+        '200':
+          $ref: '#/components/responses/AuthSuccess'
+        '422':
+          $ref: '#/components/responses/Error'
+      tags:
+        - auth
+    parameters: []
+  /api/v1/auth/sign_in:
+    post:
+      summary: ユーザーログイン
+      operationId: signIn
+      description: ユーザーログイン
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                session:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    email:
+                      type: string
+                      format: email
+                      example: test1@example.com
+                      description: メールアドレス
+                    password:
+                      type: string
+                      example: password
+                      description: パスワード
+                  required:
+                    - email
+                    - password
+            examples:
+              example-1:
+                value:
+                  session:
+                    email: test1@example.com
+                    password: password
+          application/xml:
+            schema:
+              type: object
+              properties: {}
+      responses:
+        '200':
+          $ref: '#/components/responses/AuthSuccess'
+          additionalProperties: false
+      tags:
+        - auth
+    parameters: []
+  /api/v1/auth/sign_out:
+    delete:
+      summary: 事業所利用者ログアウト
+      operationId: signOut
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    default: true
+                    description: 成功判定
+                    readOnly: true
+                required:
+                  - success
+      description: 'ヘッダーに`access-token`,`uid`,`client`必須。ログアウトする。'
+      security:
+        - access-token: []
+        - client: []
+        - expiry: []
+        - uid: []
+      tags:
+        - auth
+    parameters: []
+  /api/v1/auth/password:
+    post:
+      summary: パスワード変更
+      operationId: passwordReset
+      responses:
+        '200':
+          description: OK
+      description: パスワードをリセットし、新しいパスワードをDBに保存する
+      tags:
+        - auth
+  /api/v1/client/offices:
+    get:
+      summary: 事業所一覧取得(事業所利用者)
+      tags:
+        - office
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+              examples:
+                example-1:
+                  value:
+                    - id: 1
+                      name: 田中　太郎
+                      email: office1@example.com
+                      tel: 090-1111-2222
+                      postal: '1234567'
+                      address: 東京都新宿区市ヶ谷本村町5番1号
+                      type: OfficeRepresentative
+                      created_at: '2022-08-03T00:06:06.514+09:00'
+                      updated_at: '2022-08-03T00:06:06.514+09:00'
+                    - id: 2
+                      name: 鈴木　次郎
+                      email: office2@example.com
+                      tel: 080-1234-4444
+                      postal: '3210232'
+                      address: 栃木県下都賀郡壬生町中泉1-14-2
+                      type: OfficeRepresentative
+                      created_at: '2022-08-03T00:06:06.514+09:00'
+                      updated_at: '2022-08-03T00:06:06.514+09:00'
+                    - id: 3
+                      name: 加藤　三郎
+                      email: office3@example.com
+                      tel: 070-1242-1296
+                      postal: '0850013'
+                      address: 北海道釧路市栄町4519
+                      type: OfficeRepresentative
+                      created_at: '2022-08-03T00:06:06.514+09:00'
+                      updated_at: '2022-08-03T00:06:06.514+09:00'
+      operationId: getClientOffices
+      description: 事業所一覧を取得する。
+      parameters:
+        - schema:
+            type: string
+            example: 東京 大阪 群馬
+          in: query
+          name: q
+          description: addressを前方一致検索する。OR検索は半角スペースで区切る。
+        - schema:
+            type: string
+          in: query
+          name: page
+          description: ページネーション
+    parameters: []
+  '/api/v1/client/office/{id}':
+    get:
+      summary: 事業所詳細取得(事業所利用者)
+      tags:
+        - office
+      responses:
+        '200':
+          description: OK
+      operationId: getClientOffice
+      description: 単一の事務所の詳細を取得する
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          example: 1
+          format: int64
+        description: 対象のid
+  '/api/v1/manager/office/{id}':
+    get:
+      summary: 事業所詳細取得(ケアマネ)
+      tags:
+        - office
+      responses:
+        '200':
+          description: OK
+      operationId: getManagerOffice
+      description: 単一の事務所の詳細を取得する
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          example: 1
+          format: int64
+        description: 対象のid
+    patch:
+      summary: 事業所更新(ケアマネ)
+      operationId: updateManagerOffice
+      responses:
+        '200':
+          description: OK
+      tags:
+        - office
+      description: 単一の事務所を更新する
+  /api/v1/client/appointments:
+    post:
+      summary: 予約作成(事業所利用者)
+      operationId: createClientAppointment
+      responses:
+        '200':
+          description: OK
+      tags:
+        - appointment
+      description: ホームケアを予約する
+    get:
+      summary: 予約一覧取得(事業所利用者)
+      operationId: getClientAppointments
+      responses:
+        '200':
+          description: OK
+      description: 予約一覧を取得する
+      tags:
+        - appointment
+    parameters: []
+  /api/v1/manager/appointments:
+    get:
+      summary: 予約一覧取得(ケアマネ)
+      operationId: getManagerAppointments
+      responses:
+        '200':
+          description: OK
+      description: 予約一覧を取得する
+      tags:
+        - appointment
+    parameters: []
+  '/api/v1/manager/appointment/{id}':
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          example: 1
+          format: int64
+        description: 対象のid
+    patch:
+      summary: 予約更新(ケアマネ)
+      operationId: updateManagerAppointment
+      responses:
+        '200':
+          description: OK
+      description: 予約を更新する
+      tags:
+        - appointment
+  /api/v1/client/thanks:
+    post:
+      summary: お礼投稿(事業所利用者)
+      operationId: createClientThank
+      responses:
+        '200':
+          description: OK
+      tags:
+        - thank
+      description: お礼を投稿する
+    get:
+      summary: お礼一覧取得(事業所利用者)
+      operationId: getClientThanks
+      responses:
+        '200':
+          description: OK
+      description: お礼一覧を取得する
+      tags:
+        - thank
+    parameters: []
+  /api/v1/manager/thanks:
+    get:
+      summary: お礼一覧取得(ケアマネ)
+      operationId: getManagerThanks
+      responses:
+        '200':
+          description: OK
+      description: お礼一覧を取得する
+      tags:
+        - thank
+    parameters: []
+  '/api/v1/client/thank/{id}':
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          example: 1
+          format: int64
+        description: 対象のid
+    delete:
+      summary: お礼削除(事業所利用者)
+      operationId: deleteClientThank
+      responses:
+        '200':
+          description: OK
+      description: お礼を削除する
+      tags:
+        - thank
+    patch:
+      summary: お礼更新(事業所利用者)
+      operationId: updateClientThank
+      responses:
+        '200':
+          description: OK
+      tags:
+        - thank
+      description: お礼を更新する
+  '/api/v1/manager/thank/{id}':
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          example: 1
+          format: int64
+        description: 対象のid
+    delete:
+      summary: お礼削除(ケアマネ)
+      operationId: deleteManagerThank
+      responses:
+        '200':
+          description: OK
+      description: お礼を削除する
+      tags:
+        - thank
+  /api/v1/client/histories:
+    get:
+      summary: 閲覧履歴一覧取得(事業所利用者)
+      tags:
+        - history
+      responses:
+        '200':
+          description: OK
+      operationId: getClientHistories
+      description: 事業所の閲覧履歴を取得する
+    parameters: []
+  /api/v1/client/bookmarks:
+    get:
+      summary: ブックマーク一覧取得(事業所利用者)
+      tags:
+        - book_mark
+      responses:
+        '200':
+          description: OK
+      operationId: getClientBookmarks
+      description: ブックマークをつけた事業所一覧を取得する
+    post:
+      summary: ブックマーク作成(事業所利用者)
+      operationId: createClientBookmark
+      responses:
+        '200':
+          description: OK
+      tags:
+        - book_mark
+      description: ブックマークを作成する
+    parameters: []
+  '/api/v1/client/book_mark/{id}':
+    delete:
+      summary: ブックマーク削除(事業所利用者)
+      operationId: deleteClientBookmark
+      responses:
+        '200':
+          description: OK
+      tags:
+        - book_mark
+      description: ブックマークを削除する
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          example: 1
+          format: int64
+        description: 対象のid
+  /api/v1/client/staffs:
+    get:
+      summary: スタッフ一覧取得(事業所利用者)
+      responses:
+        '200':
+          description: OK
+      operationId: getClientStaffs
+      tags:
+        - staff
+      description: スタッフ一覧を取得する
+    parameters: []
+  /api/v1/manager/staffs:
+    get:
+      summary: スタッフ一覧取得(ケアマネ)
+      responses:
+        '200':
+          description: OK
+      operationId: getManagerStaffs
+      tags:
+        - staff
+      description: スタッフ一覧を取得する
+    post:
+      summary: スタッフ作成(ケアマネ)
+      operationId: createManagerStaff
+      responses:
+        '200':
+          description: OK
+      tags:
+        - staff
+      description: スタッフを追加する
+    parameters: []
+  '/api/v1/manager/staff/{id}':
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          example: 1
+          format: int64
+        description: 対象のid
+    delete:
+      summary: スタッフ削除(ケアマネ)
+      operationId: deleteManagerStaff
+      responses:
+        '200':
+          description: OK
+      tags:
+        - staff
+      description: スタッフを削除する
+    patch:
+      summary: スタッフ更新(ケアマネ)
+      operationId: updateManagerStaff
+      responses:
+        '200':
+          description: OK
+      tags:
+        - staff
+      description: スタッフを更新する
+  /api/v1/manager/office_clients:
+    get:
+      summary: 事業所管理の事業所利用者一覧取得(ケアマネ)
+      responses:
+        '200':
+          description: OK
+      operationId: getManagerOfficeClients
+      tags:
+        - office_client
+      description: 事業所で管理している事業所利用者一覧を取得する
+    parameters: []
+    post:
+      summary: 事業所管理の事業所利用者作成(ケアマネ)
+      operationId: createManagerOfficeClient
+      responses:
+        '200':
+          description: OK
+      tags:
+        - office_client
+      description: 事業所で管理している事業所利用者を作成する
+  '/api/v1/manager/office_client/{id}':
+    patch:
+      summary: 事業所管理の事業所利用者更新(ケアマネ)
+      operationId: updateManagerOfficeClient
+      responses:
+        '200':
+          description: OK
+      tags:
+        - office_client
+      description: 事業所で管理している事業所利用者一覧を更新する
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          example: 1
+          format: int64
+        description: 対象のid
+    delete:
+      summary: 事業所管理の事業所利用者削除(ケアマネ)
+      operationId: deleteManagerOfficeClient
+      responses:
+        '200':
+          description: OK
+      tags:
+        - office_client
+      description: 事業所で管理している事業所利用者一覧を削除する
+components:
+  schemas:
+    User:
+      type: object
+      title: User
+      x-stoplight:
+        id: ygtg1gffnd7xu
+      description: 事業所利用者及び事業所代表者
+      properties:
+        id:
+          type: number
+          example: 1
+          description: ID
+          readOnly: true
+        name:
+          type: string
+          description: 名前
+          example: テスト 太郎
+        email:
+          type: string
+          format: email
+          example: test@example.com
+          description: メールアドレス
+        tel:
+          type: string
+          description: 電話番号
+          example: 090-1111-2222
+          pattern: '^0[-0-9]{11,12}$'
+        postal:
+          type: string
+          example: '1234567'
+          pattern: '^\d{7}$'
+          description: 郵便番号
+          maxLength: 7
+        address:
+          type: string
+          example: 東京都新宿区市ヶ谷本村町5番1号
+          description: 住所
+        type:
+          type: string
+          example: Client
+          description: STIによるユーザー識別文字列
+        created_at:
+          type: string
+          format: date-time
+          example: '2022-08-03T00:06:06.514+09:00'
+          description: 作成日時
+        updated_at:
+          type: string
+          format: date-time
+          example: '2022-08-03T00:06:06.514+09:00'
+          description: 更新日時
+      required:
+        - id
+        - name
+        - email
+        - tel
+        - postal
+        - address
+        - type
+        - created_at
+        - updated_at
+  responses:
+    AuthSuccess:
+      description: ''
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            properties:
+              status:
+                type: string
+                example: success
+                description: successまたはerror
+                readOnly: true
+              data:
+                allOf:
+                  - type: object
+                    description: 認証情報
+                    properties:
+                      provider:
+                        type: string
+                        example: email
+                        default: email
+                        description: emailやOmniauth等の認証方式
+                      uid:
+                        type: string
+                        format: email
+                        example: test1@example.com
+                        description: ユーザー識別子
+                      allow_password_change:
+                        type: boolean
+                        default: false
+                        description: パスワード変更中判定
+                        readOnly: true
+                    required:
+                      - provider
+                      - uid
+                      - allow_password_change
+                  - $ref: '#/components/schemas/User'
+                description: ユーザー及び認証情報
+            required:
+              - status
+              - data
+          examples:
+            example-1:
+              value:
+                status: success
+                data:
+                  provider: email
+                  uid: test1@example.com
+                  allow_password_change: false
+                  id: 1
+                  name: テスト 太郎
+                  email: test@example.com
+                  tel: 090-1111-2222
+                  postal: '1234567'
+                  address: 東京都新宿区市ヶ谷本村町5番1号
+                  type: Client
+                  created_at: '2022-08-03T00:06:06.514+09:00'
+                  updated_at: '2022-08-03T00:06:06.514+09:00'
+      headers:
+        access-token:
+          schema:
+            type: string
+            example: 7sbMLu90-fDnajzasuhOTQ
+          description: トークン認証に必要なヘッダー(1/4)
+        client:
+          schema:
+            type: string
+            example: xJ-BFLHzY_XNMX_cjsQnPw
+          description: トークン認証に必要なヘッダー(2/4)
+        expiry:
+          schema:
+            type: number
+            example: 1660145125
+          description: トークン認証に必要なヘッダー(3/4)
+        uid:
+          schema:
+            type: string
+            example: test1@example.com
+          description: トークン認証に必要なヘッダー(4/4)
+    Error:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            allOf:
+              - properties:
+                  status:
+                    type: string
+                    default: error
+                    example: error
+                    description: エラーステータス
+                    readOnly: true
+                required:
+                  - status
+              - properties:
+                  data:
+                    type: object
+                    description: レスポンスによって異なる
+                required:
+                  - data
+              - properties:
+                  errors:
+                    type: object
+                    required:
+                      - full_messages
+                    description: エラー情報
+                    properties:
+                      full_messages:
+                        type: array
+                        description: すべてのエラーメッセージ
+                        items:
+                          type: string
+                          example: メールアドレスはすでに存在します
+                required:
+                  - errors
+            type: object
+          examples:
+            example-1:
+              value:
+                status: error
+                data: {}
+                errors:
+                  full_messages:
+                    - メールアドレスはすでに存在します
+  requestBodies:
+    Registration:
+      content:
+        application/json:
+          schema:
+            allOf:
+              - properties:
+                  registration:
+                    type: object
+                    required:
+                      - name
+                      - email
+                      - tel
+                      - postal
+                      - address
+                      - password
+                      - type
+                    properties:
+                      name:
+                        type: string
+                        description: 名前
+                        example: テスト 太郎
+                      email:
+                        type: string
+                        format: email
+                        example: test@example.com
+                        description: メールアドレス
+                      tel:
+                        type: string
+                        description: 電話番号
+                        example: 090-1111-2222
+                        pattern: '^0[-0-9]{11,12}$'
+                      postal:
+                        type: string
+                        example: '1234567'
+                        pattern: '^\d{7}$'
+                        description: 郵便番号
+                        maxLength: 7
+                      address:
+                        type: string
+                        example: 東京都新宿区市ヶ谷本村町5番1号
+                        description: 住所
+                      password:
+                        type: string
+                        example: password
+                        description: パスワード
+                      type:
+                        type: string
+                        example: Client
+                        description: STIによるユーザー識別文字列
+                required:
+                  - registration
+              - properties:
+                  confirm_success_url:
+                    type: string
+                    format: uri
+                    example: 'https://www.home-care-navi-second'
+                    description: アカウント登録メールに記載されるURL
+                required:
+                  - confirm_success_url
+            type: object
+          examples:
+            example-1:
+              value:
+                registration:
+                  name: テスト 太郎
+                  email: test@example.com
+                  tel: 090-1111-2222
+                  postal: '1234567'
+                  address: 東京都新宿区市ヶ谷本村町5番1号
+                  password: password
+                  type: Client
+                confirm_success_url: 'https://www.home-care-navi-second'
+      description: ''
+  parameters: {}
+  securitySchemes:
+    access-token:
+      name: access-token
+      type: apiKey
+      in: header
+      description: トークン認証に必要なヘッダー(1/4)
+    client:
+      name: client
+      type: apiKey
+      in: header
+      description: トークン認証に必要なヘッダー(2/4)
+    expiry:
+      name: expiry
+      type: apiKey
+      in: header
+      description: トークン認証に必要なヘッダー(3/4)
+    uid:
+      name: uid
+      type: apiKey
+      in: header
+      description: トークン認証に必要なヘッダー(4/4)
+tags:
+  - name: appointment
+    description: 予約
+  - name: auth
+    description: 認証
+  - name: book_mark
+    description: ブックマーク
+  - name: client
+    description: 事業所利用者が使用するエンドポイント
+  - name: health_check
+    description: ヘルスチェック関連
+  - name: history
+    description: 閲覧履歴
+  - name: office
+    description: 事業所
+  - name: office_client
+    description: 事業所で管理しているクライアント
+  - name: staff
+    description: 事業所スタッフ
+  - name: thank
+    description: お礼

--- a/lib/tasks/development/fetch_openapi.rake
+++ b/lib/tasks/development/fetch_openapi.rake
@@ -1,0 +1,10 @@
+require 'net/http'
+
+namespace :development do
+  desc 'githubから最新のopenapiを取得する'
+  task :fetch_openapi do
+    res = Net::HTTP.get_response URI('https://raw.githubusercontent.com/rahhi555/homeCareNavi_2nd_OpenAPI/master/reference/home-care-navi-second-open-api.yaml')
+    new_file = File.open('home-care-navi-second-open-api.yaml', 'w')
+    new_file.write(res.body.force_encoding('UTF-8'))
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,7 +66,7 @@ RSpec.configure do |config|
   config.include Committee::Rails::Test::Methods
   config.add_setting :committee_options
   config.committee_options = {
-    schema_path: '/reference/home-care-navi-second-open-api.yaml',
+    schema_path: Rails.root.join('home-care-navi-second-open-api.yaml').to_s,
     query_hash_key: 'rack.request.query_hash',
     parse_response_by_content_type: false
   }


### PR DESCRIPTION
OpenAPIリポジトリをクローンせずとも、githubから直接取得あるいは参照が可能なため、compose.ymlやREADME等修正

また、[committee-rails](https://github.com/willnet/committee-rails)は使用するスキーマのurl指定が不可能であるため、`rake development:fetch_openapi`でgithubから最新のスキーマをダウンロードできるよう機能追加