### PR TITLE
ユーザー更新がpassword以外出来ていなかった現象を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ coverage
 .rdbg_history
 spec/examples.txt
 
+.cache

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,8 @@ class ApplicationController < ActionController::API
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up,
-                                      keys: %i[name email tel postal address password type])
+    keys = %i[name email tel postal address password type]
+    devise_parameter_sanitizer.permit(:sign_up, keys:)
+    devise_parameter_sanitizer.permit(:account_update, keys:)
   end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.

--- a/lib/tasks/production/start.rake
+++ b/lib/tasks/production/start.rake
@@ -3,7 +3,7 @@ namespace :production do
   task start: :environment do
     sh 'rails db:create'
     sh 'rails db:migrate'
-    port = ENV['SERVER_PORT']
+    port = ENV.fetch('SERVER_PORT', nil)
     sh "rails s -b '0.0.0.0' -p #{port}"
   end
 end

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -8,6 +8,5 @@ FactoryBot.define do
     password { Faker::Internet.password }
     type { 'Client' }
     confirmed_at { Date.current.in_time_zone }
-    discarded_at { nil }
   end
 end


### PR DESCRIPTION
## チケット
resolved #43 

## やったこと
ユーザー更新のAPIを叩いてもpassword及びemail以外更新出来ていなかった現象の修正

## できるようになること（ユーザ目線）
- 名前や住所も更新できるようになる

## OpenAPI
APIエンドポイントの実装・変更をした場合、対応するOpenAPIのリンクを記載する
- https://rahhi555.stoplight.io/docs/home-care-navi-second/d2081891d746b-