### PR TITLE
施設概要モデル(OfficeOverview)およびエンドポイント作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,11 @@ Rails/RakeEnvironment:
   Exclude:
     - 'lib/tasks/development/fetch_openapi.rake'
 
+RSpec:
+  Language:
+    Expectations:
+      - assert_response_schema_confirm
+
 RSpec/NestedGroups:
   Enabled: false
 

--- a/app/controllers/api/v1/manager/office_overviews_controller.rb
+++ b/app/controllers/api/v1/manager/office_overviews_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Manager
+      class OfficeOverviewsController < ApplicationController
+        before_action :authenticate_api_v1_manager!
+
+        def show
+          office_overview = current_api_v1_user.office.office_overview
+          render json: office_overview, status: :ok
+        end
+
+        def update
+          office_overview = current_api_v1_user.office.office_overview
+          if office_overview.update(office_overview_params)
+            render json: office_overview, status: :ok
+          else
+            render json: office_overview.as_error_json, status: :bad_request
+          end
+        end
+
+        private
+
+        def office_overview_params
+          params.permit(:classify, :opening_date, :room_count, :requirements, :shared_facilities, :business_entity,
+                        :official_site_url)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/overrides/registrations_controller.rb
+++ b/app/controllers/api/v1/overrides/registrations_controller.rb
@@ -21,8 +21,11 @@ module Api
 
         def build_resource
           super
-          # User.typeがManagerの場合、Officeも同時に作成する
-          @resource.build_office_with_location if @resource&.manager?
+          # User.typeがManagerの場合、Office及びOfficeOverviewも同時に作成する
+          if @resource&.manager?
+            office = @resource.build_office_with_location
+            office.build_office_overview
+          end
         end
       end
     end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  def as_error_json
+    { errors: errors.full_messages }
+  end
 end

--- a/app/models/concerns/ensure_destroyed_by_association.rb
+++ b/app/models/concerns/ensure_destroyed_by_association.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# このモジュールをincludeすることで、includeしたインスタンス自身のdestroyを出来なくさせる。
+# これは1対1のリレーションにおいて、親子が必ず存在しなければならない際に、子のみの削除を防止する。
+module EnsureDestroyedByAssociation
+  extend ActiveSupport::Concern
+
+  included do
+    before_destroy do
+      # destroyed_by_associationはdependent: :destroyなどの関連付けによる削除が発生した場合はtrueを返し、
+      # 自分自身で削除した場合はfalseを返す。
+      unless destroyed_by_association
+        errors.add(:base, 'このモデルのみを削除することはできません。削除する場合は、親を削除してください。')
+        throw(:abort)
+      end
+    end
+  end
+end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,4 +1,5 @@
 class Office < ApplicationRecord
+  has_one :office_overview, dependent: :destroy
   belongs_to :manager
 
   validates :manager_id, uniqueness: true

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,15 +1,17 @@
 class Office < ApplicationRecord
+  include EnsureDestroyedByAssociation
+
   has_one :office_overview, dependent: :destroy
   belongs_to :manager
 
   validates :manager_id, uniqueness: true
-  validates :name, presence: true, length: { maximum: 100 }
-  validates :feature_title, presence: true, length: { maximum: 100 }
+  validates :name, presence: true, length: { maximum: 200 }
+  validates :feature_title, presence: true, length: { maximum: 200 }
   validates :feature_detail, presence: true
   validates :workday_detail, presence: true
   validates :lat, numericality: true
   validates :lng, numericality: true
-  validates :fax, presence: true
+  validates :fax, presence: true, length: { maximum: 200 }
   validates :nearest_station, presence: true
 
   flag :workday, %i[sun mon tue wed thu fri sat]

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -9,8 +9,8 @@ class Office < ApplicationRecord
   validates :feature_title, presence: true, length: { maximum: 200 }
   validates :feature_detail, presence: true
   validates :workday_detail, presence: true
-  validates :lat, numericality: true
-  validates :lng, numericality: true
+  validates :lat, numericality: true, allow_nil: true
+  validates :lng, numericality: true, allow_nil: true
   validates :fax, presence: true, length: { maximum: 200 }
   validates :nearest_station, presence: true
 

--- a/app/models/office_overview.rb
+++ b/app/models/office_overview.rb
@@ -1,0 +1,5 @@
+class OfficeOverview < ApplicationRecord
+  belongs_to :office
+  validates :office_id, uniqueness: true
+  validates :official_site_url, format: { with: URI::DEFAULT_PARSER.make_regexp }, allow_nil: true
+end

--- a/app/models/office_overview.rb
+++ b/app/models/office_overview.rb
@@ -1,5 +1,11 @@
 class OfficeOverview < ApplicationRecord
+  include EnsureDestroyedByAssociation
+
   belongs_to :office
   validates :office_id, uniqueness: true
+  validates :classify, length: { maximum: 200 }
+  validates :requirements, length: { maximum: 200 }
+  validates :shared_facilities, length: { maximum: 200 }
+  validates :business_entity, length: { maximum: 200 }
   validates :official_site_url, format: { with: URI::DEFAULT_PARSER.make_regexp }, allow_nil: true
 end

--- a/config/locales/models/office_overview/ja.yml
+++ b/config/locales/models/office_overview/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  activerecord:
+    models:
+      office_overview: '施設概要'
+
+    attributes:
+      office_overview:
+        office: '事業所'
+        classify: '類型'
+        opening_date: '開設年月'
+        room_count: '居室数'
+        requirements: '入居時の要件'
+        shared_facilities: '共用設備'
+        business_entity: '経営・事業主体'
+        official_site_url: '公式サイトのurl'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,17 @@
 Rails.application.routes.draw do
-  namespace :api do
+  namespace :api, format: 'json' do
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         registrations: 'api/v1/overrides/registrations',
         sessions: 'api/v1/overrides/sessions'
       }
+
+      namespace :manager do
+        resource :office_overview, only: [:show, :update]
+      end
+
+      namespace :client do
+      end
     end
   end
 

--- a/db/migrate/20221029054602_create_office_overviews.rb
+++ b/db/migrate/20221029054602_create_office_overviews.rb
@@ -1,0 +1,16 @@
+class CreateOfficeOverviews < ActiveRecord::Migration[7.0]
+  def change
+    create_table :office_overviews do |t|
+      t.references :office, null: false, foreign_key: true, index: { unique: true }
+      t.string :classify, comment: '類型'
+      t.date :opening_date, comment: '開設年月'
+      t.integer :room_count, comment: '居室数'
+      t.string :requirements, comment: '入居時の要件'
+      t.string :shared_facilities, comment: '共用設備'
+      t.string :business_entity, comment: '経営・事業主体'
+      t.string :official_site_url, comment: '公式サイトのurl'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_24_135504) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_29_054602) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "office_overviews", force: :cascade do |t|
+    t.bigint "office_id", null: false
+    t.string "classify", comment: "類型"
+    t.date "opening_date", comment: "開設年月"
+    t.integer "room_count", comment: "居室数"
+    t.string "requirements", comment: "入居時の要件"
+    t.string "shared_facilities", comment: "共用設備"
+    t.string "business_entity", comment: "経営・事業主体"
+    t.string "official_site_url", comment: "公式サイトのurl"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["office_id"], name: "index_office_overviews_on_office_id", unique: true
+  end
 
   create_table "offices", force: :cascade do |t|
     t.bigint "manager_id", null: false
@@ -65,5 +79,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_24_135504) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "office_overviews", "offices"
   add_foreign_key "offices", "users", column: "manager_id"
 end

--- a/home-care-navi-second-open-api.yaml
+++ b/home-care-navi-second-open-api.yaml
@@ -465,14 +465,20 @@ paths:
                   type: string
                   example: password
                   description: パスワード
+                type:
+                  type: string
+                  example: Client
+                  description: ユーザーの種別
               required:
                 - email
                 - password
+                - type
             examples:
               example-1:
                 value:
                   email: test1@example.com
                   password: password
+                  type: Client
           application/xml:
             schema:
               type: object
@@ -832,7 +838,7 @@ paths:
           example: 1
           format: int64
         description: 対象のid
-  '/api/v1/manager/office/{id}':
+  /api/v1/manager/office:
     get:
       summary: 事業所詳細取得(ケアマネ)
       tags:
@@ -840,27 +846,174 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Office'
+              examples:
+                example-1:
+                  value:
+                    id: 1
+                    manager_id: 5
+                    name: ホームケア事務所_1
+                    feature_title: 事業所紹介タイトル
+                    feature_detail: ここに事業所の特徴テキストが入ります
+                    workday:
+                      - mon
+                    workday_detail: 営業日時についてのテキストが入ります
+                    lat: '43.073211'
+                    lng: '41.350427'
+                    fax: 111-2222-3333
+                    nearest_station: 北12条駅 徒歩5分
+                    created_at: string
+                    updated_at: string
       operationId: getManagerOffice
-      description: 単一の事務所の詳細を取得する
-    parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: integer
-          example: 1
-          format: int64
-        description: 対象のid
+      description: Manager自身の事務所詳細を取得する
+    parameters: []
     patch:
       summary: 事業所更新(ケアマネ)
       operationId: updateManagerOffice
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Office'
+              examples:
+                example-1:
+                  value:
+                    id: 1
+                    manager_id: 5
+                    name: ホームケア事務所_1
+                    feature_title: 事業所紹介タイトル
+                    feature_detail: ここに事業所の特徴テキストが入ります
+                    workday:
+                      - mon
+                    workday_detail: 営業日時についてのテキストが入ります
+                    lat: '43.073211'
+                    lng: '41.350427'
+                    fax: 111-2222-3333
+                    nearest_station: 北12条駅 徒歩5分
+                    created_at: string
+                    updated_at: string
       tags:
         - office
-      description: 単一の事務所を更新する
-  /api/v1/client/appointments:
+      description: Manager自身の事務所を更新する
+  /api/v1/manager/office_overview:
+    parameters: []
+    patch:
+      summary: 施設概要更新(ケアマネ)
+      operationId: updateManagerOfficeOverview
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OfficeOverview'
+              examples:
+                example-1:
+                  value:
+                    id: 1
+                    office_id: 3
+                    classify: 介護付きホーム（サービス付き高齢者向け住宅　特定施設）
+                    opening_date: '2022-03-11'
+                    room_count: 30
+                    requirements: 満60歳以上の方、入居時自立・要支援・要介護
+                    shared_facilities: エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園
+                    business_entity: 株式会社ユニマット　リタイアメント・コミュニティ
+                    official_site_url: 'https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html'
+                    created_at: '2022-10-29T18:22:43.829+09:00'
+                    updated_at: '2022-10-29T18:22:43.829+09:00'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+      description: Manager自身の施設概要を更新する
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                classify:
+                  type: string
+                  description: 類型
+                  example: 介護付きホーム（サービス付き高齢者向け住宅　特定施設）
+                opening_date:
+                  type: string
+                  description: 開設年月
+                  example: '2022-03-11'
+                  format: date
+                room_count:
+                  type: integer
+                  description: 居室数
+                  example: 30
+                requirements:
+                  type: string
+                  description: 入居時の要件
+                  example: 満60歳以上の方、入居時自立・要支援・要介護
+                shared_facilities:
+                  type: string
+                  description: 共用設備
+                  example: エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園
+                business_entity:
+                  type: string
+                  description: 経営・事業主体
+                  example: 株式会社ユニマット　リタイアメント・コミュニティ
+                official_site_url:
+                  type: string
+                  description: 公式サイトのURL
+                  example: 'https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html'
+                  format: uri
+              required:
+                - classify
+                - opening_date
+                - room_count
+                - requirements
+                - shared_facilities
+                - business_entity
+                - official_site_url
+            examples:
+              example-1:
+                value:
+                  classify: 介護付きホーム（サービス付き高齢者向け住宅　特定施設）
+                  opening_date: '2022-03-11'
+                  room_count: 30
+                  requirements: 満60歳以上の方、入居時自立・要支援・要介護
+                  shared_facilities: エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園
+                  business_entity: 株式会社ユニマット　リタイアメント・コミュニティ
+                  official_site_url: 'https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html'
+        description: ''
+      tags:
+        - office_overview
+    get:
+      summary: 施設概要取得（ケアマネ）
+      operationId: getManagerOfficeOverview
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OfficeOverview'
+              examples:
+                example-1:
+                  value:
+                    id: 1
+                    office_id: 3
+                    classify: 介護付きホーム（サービス付き高齢者向け住宅　特定施設）
+                    opening_date: '2022-03-11'
+                    room_count: 30
+                    requirements: 満60歳以上の方、入居時自立・要支援・要介護
+                    shared_facilities: エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園
+                    business_entity: 株式会社ユニマット　リタイアメント・コミュニティ
+                    official_site_url: 'https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html'
+                    created_at: '2022-10-29T18:22:43.829+09:00'
+                    updated_at: '2022-10-29T18:22:43.829+09:00'
+      description: Manager自身の施設概要を取得する
+      tags:
+        - office_overview
+  /api/v1/client/reserves:
     post:
       summary: 予約作成(事業所利用者)
       operationId: createClientAppointment
@@ -872,7 +1025,7 @@ paths:
       description: ホームケアを予約する
     get:
       summary: 予約一覧取得(事業所利用者)
-      operationId: getClientAppointments
+      operationId: getClientReserves
       responses:
         '200':
           description: OK
@@ -880,10 +1033,10 @@ paths:
       tags:
         - appointment
     parameters: []
-  /api/v1/manager/appointments:
+  /api/v1/manager/reserves:
     get:
       summary: 予約一覧取得(ケアマネ)
-      operationId: getManagerAppointments
+      operationId: getManagerReserves
       responses:
         '200':
           description: OK
@@ -891,7 +1044,7 @@ paths:
       tags:
         - appointment
     parameters: []
-  '/api/v1/manager/appointment/{id}':
+  '/api/v1/manager/reserve/{id}':
     parameters:
       - name: id
         in: path
@@ -903,7 +1056,7 @@ paths:
         description: 対象のid
     patch:
       summary: 予約更新(ケアマネ)
-      operationId: updateManagerAppointment
+      operationId: updateManagerReserve
       responses:
         '200':
           description: OK
@@ -1225,6 +1378,153 @@ components:
         - provider
         - uid
         - allow_password_change
+    Office:
+      type: object
+      x-examples:
+        Example 1:
+          id: 1
+          manager_id: 5
+          name: ホームケア事務所_1
+          feature_title: 事業所紹介タイトル
+          feature_detail: ここに事業所の特徴テキストが入ります
+          workday:
+            - mon
+          workday_detail: 営業日時についてのテキストが入ります
+          lat: '43.073211'
+          lng: '141.350427'
+          fax: 111-2222-3333
+          nearest_station: 北12条駅 徒歩5分
+          created_at: '2022-10-29T00:47:31.090+09:00'
+          updated_at: '2022-10-29T00:47:31.090+09:00'
+      title: Office
+      description: 事業所
+      properties:
+        id:
+          type: integer
+          example: 1
+        manager_id:
+          type: integer
+          example: 5
+        name:
+          type: string
+          example: ホームケア事務所_1
+        feature_title:
+          type: string
+          example: 事業所紹介タイトル
+        feature_detail:
+          type: string
+          example: ここに事業所の特徴テキストが入ります
+        workday:
+          type: array
+          example:
+            - mon
+          items:
+            type: string
+        workday_detail:
+          type: string
+          example: 営業日時についてのテキストが入ります
+        lat:
+          type: string
+          example: '43.073211'
+        lng:
+          type: string
+          example: '41.350427'
+        fax:
+          type: string
+          example: 111-2222-3333
+        nearest_station:
+          type: string
+          example: 北12条駅 徒歩5分
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      required:
+        - id
+        - manager_id
+        - name
+        - feature_title
+        - feature_detail
+        - workday
+        - workday_detail
+        - lat
+        - lng
+        - fax
+        - nearest_station
+    OfficeOverview:
+      type: object
+      x-examples:
+        Example 1:
+          id: 3
+          office_id: 56
+          classify: 介護付きホーム（サービス付き高齢者向け住宅　特定施設）
+          opening_date: '2022-03-11'
+          room_count: 30
+          requirements: 満60歳以上の方、入居時自立・要支援・要介護
+          shared_facilities: エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園
+          business_entity: 株式会社ユニマット　リタイアメント・コミュニティ
+          official_site_url: 'https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html'
+          created_at: '2022-10-29T18:22:43.829+09:00'
+          updated_at: '2022-10-29T18:22:43.829+09:00'
+      title: OfficeOverview
+      description: 施設概要
+      properties:
+        id:
+          type: integer
+          description: 主キー
+          example: 1
+        office_id:
+          type: integer
+          description: 事業所外部キー
+          example: 3
+        classify:
+          type: string
+          description: 類型
+          example: 介護付きホーム（サービス付き高齢者向け住宅　特定施設）
+        opening_date:
+          type: string
+          description: 開設年月
+          example: '2022-03-11'
+          format: date
+        room_count:
+          type: integer
+          description: 居室数
+          example: 30
+        requirements:
+          type: string
+          description: 入居時の要件
+          example: 満60歳以上の方、入居時自立・要支援・要介護
+        shared_facilities:
+          type: string
+          description: 共用設備
+          example: エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園
+        business_entity:
+          type: string
+          description: 経営・事業主体
+          example: 株式会社ユニマット　リタイアメント・コミュニティ
+        official_site_url:
+          type: string
+          description: 公式サイトのURL
+          example: 'https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html'
+          format: uri
+        created_at:
+          type: string
+          example: '2022-10-29T18:22:43.829+09:00'
+        updated_at:
+          type: string
+          example: '2022-10-29T18:22:43.829+09:00'
+      required:
+        - id
+        - office_id
+        - classify
+        - opening_date
+        - room_count
+        - requirements
+        - shared_facilities
+        - business_entity
+        - official_site_url
+        - created_at
+        - updated_at
   responses:
     AuthSuccess:
       description: ''
@@ -1278,6 +1578,22 @@ components:
             type: string
             example: test1@example.com
           description: トークン認証に必要なヘッダー(4/4)
+    BadRequest:
+      description: 'バリデーションチェック失敗時。status: :bad_requestで返ってくるときの値。'
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              errors:
+                type: array
+                description: エラーの値
+                items:
+                  type: string
+                example:
+                  - 類型は200文字以内で入力してください
+            required:
+              - errors
   requestBodies: {}
   parameters: {}
   securitySchemes:
@@ -1320,6 +1636,8 @@ tags:
     description: 事業所
   - name: office_client
     description: 事業所で管理しているクライアント
+  - name: office_overview
+    description: 施設概要
   - name: staff
     description: 事業所スタッフ
   - name: thank

--- a/sig/app/models/application_record.rbs
+++ b/sig/app/models/application_record.rbs
@@ -1,2 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
+  def as_error_json: () -> Hash[Symbol, String]
 end

--- a/sig/rbs_rails/app/models/office.rbs
+++ b/sig/rbs_rails/app/models/office.rbs
@@ -472,6 +472,12 @@ class Office < ::ApplicationRecord
   end
   include GeneratedAttributeMethods
 
+  def office_overview: () -> OfficeOverview?
+  def office_overview=: (OfficeOverview?) -> OfficeOverview?
+  def build_office_overview: (untyped) -> OfficeOverview
+  def create_office_overview: (untyped) -> OfficeOverview
+  def create_office_overview!: (untyped) -> OfficeOverview
+  def reload_office_overview: () -> OfficeOverview?
   def manager: () -> Manager
   def manager=: (Manager?) -> Manager?
   def reload_manager: () -> Manager?

--- a/sig/rbs_rails/app/models/office_overview.rbs
+++ b/sig/rbs_rails/app/models/office_overview.rbs
@@ -1,0 +1,426 @@
+class OfficeOverview < ::ApplicationRecord
+  extend _ActiveRecord_Relation_ClassMethods[OfficeOverview, ActiveRecord_Relation, Integer]
+
+  module GeneratedAttributeMethods
+    def id: () -> Integer
+
+    def id=: (Integer) -> Integer
+
+    def id?: () -> bool
+
+    def id_changed?: () -> bool
+
+    def id_change: () -> [ Integer?, Integer? ]
+
+    def id_will_change!: () -> void
+
+    def id_was: () -> Integer?
+
+    def id_previously_changed?: () -> bool
+
+    def id_previous_change: () -> Array[Integer?]?
+
+    def id_previously_was: () -> Integer?
+
+    def id_before_last_save: () -> Integer?
+
+    def id_change_to_be_saved: () -> Array[Integer?]?
+
+    def id_in_database: () -> Integer?
+
+    def saved_change_to_id: () -> Array[Integer?]?
+
+    def saved_change_to_id?: () -> bool
+
+    def will_save_change_to_id?: () -> bool
+
+    def restore_id!: () -> void
+
+    def clear_id_change: () -> void
+
+    def office_id: () -> Integer
+
+    def office_id=: (Integer) -> Integer
+
+    def office_id?: () -> bool
+
+    def office_id_changed?: () -> bool
+
+    def office_id_change: () -> [ Integer?, Integer? ]
+
+    def office_id_will_change!: () -> void
+
+    def office_id_was: () -> Integer?
+
+    def office_id_previously_changed?: () -> bool
+
+    def office_id_previous_change: () -> Array[Integer?]?
+
+    def office_id_previously_was: () -> Integer?
+
+    def office_id_before_last_save: () -> Integer?
+
+    def office_id_change_to_be_saved: () -> Array[Integer?]?
+
+    def office_id_in_database: () -> Integer?
+
+    def saved_change_to_office_id: () -> Array[Integer?]?
+
+    def saved_change_to_office_id?: () -> bool
+
+    def will_save_change_to_office_id?: () -> bool
+
+    def restore_office_id!: () -> void
+
+    def clear_office_id_change: () -> void
+
+    def classify: () -> String?
+
+    def classify=: (String?) -> String?
+
+    def classify?: () -> bool
+
+    def classify_changed?: () -> bool
+
+    def classify_change: () -> [ String?, String? ]
+
+    def classify_will_change!: () -> void
+
+    def classify_was: () -> String?
+
+    def classify_previously_changed?: () -> bool
+
+    def classify_previous_change: () -> Array[String?]?
+
+    def classify_previously_was: () -> String?
+
+    def classify_before_last_save: () -> String?
+
+    def classify_change_to_be_saved: () -> Array[String?]?
+
+    def classify_in_database: () -> String?
+
+    def saved_change_to_classify: () -> Array[String?]?
+
+    def saved_change_to_classify?: () -> bool
+
+    def will_save_change_to_classify?: () -> bool
+
+    def restore_classify!: () -> void
+
+    def clear_classify_change: () -> void
+
+    def opening_date: () -> Date?
+
+    def opening_date=: (Date?) -> Date?
+
+    def opening_date?: () -> bool
+
+    def opening_date_changed?: () -> bool
+
+    def opening_date_change: () -> [ Date?, Date? ]
+
+    def opening_date_will_change!: () -> void
+
+    def opening_date_was: () -> Date?
+
+    def opening_date_previously_changed?: () -> bool
+
+    def opening_date_previous_change: () -> Array[Date?]?
+
+    def opening_date_previously_was: () -> Date?
+
+    def opening_date_before_last_save: () -> Date?
+
+    def opening_date_change_to_be_saved: () -> Array[Date?]?
+
+    def opening_date_in_database: () -> Date?
+
+    def saved_change_to_opening_date: () -> Array[Date?]?
+
+    def saved_change_to_opening_date?: () -> bool
+
+    def will_save_change_to_opening_date?: () -> bool
+
+    def restore_opening_date!: () -> void
+
+    def clear_opening_date_change: () -> void
+
+    def room_count: () -> Integer?
+
+    def room_count=: (Integer?) -> Integer?
+
+    def room_count?: () -> bool
+
+    def room_count_changed?: () -> bool
+
+    def room_count_change: () -> [ Integer?, Integer? ]
+
+    def room_count_will_change!: () -> void
+
+    def room_count_was: () -> Integer?
+
+    def room_count_previously_changed?: () -> bool
+
+    def room_count_previous_change: () -> Array[Integer?]?
+
+    def room_count_previously_was: () -> Integer?
+
+    def room_count_before_last_save: () -> Integer?
+
+    def room_count_change_to_be_saved: () -> Array[Integer?]?
+
+    def room_count_in_database: () -> Integer?
+
+    def saved_change_to_room_count: () -> Array[Integer?]?
+
+    def saved_change_to_room_count?: () -> bool
+
+    def will_save_change_to_room_count?: () -> bool
+
+    def restore_room_count!: () -> void
+
+    def clear_room_count_change: () -> void
+
+    def requirements: () -> String?
+
+    def requirements=: (String?) -> String?
+
+    def requirements?: () -> bool
+
+    def requirements_changed?: () -> bool
+
+    def requirements_change: () -> [ String?, String? ]
+
+    def requirements_will_change!: () -> void
+
+    def requirements_was: () -> String?
+
+    def requirements_previously_changed?: () -> bool
+
+    def requirements_previous_change: () -> Array[String?]?
+
+    def requirements_previously_was: () -> String?
+
+    def requirements_before_last_save: () -> String?
+
+    def requirements_change_to_be_saved: () -> Array[String?]?
+
+    def requirements_in_database: () -> String?
+
+    def saved_change_to_requirements: () -> Array[String?]?
+
+    def saved_change_to_requirements?: () -> bool
+
+    def will_save_change_to_requirements?: () -> bool
+
+    def restore_requirements!: () -> void
+
+    def clear_requirements_change: () -> void
+
+    def shared_facilities: () -> String?
+
+    def shared_facilities=: (String?) -> String?
+
+    def shared_facilities?: () -> bool
+
+    def shared_facilities_changed?: () -> bool
+
+    def shared_facilities_change: () -> [ String?, String? ]
+
+    def shared_facilities_will_change!: () -> void
+
+    def shared_facilities_was: () -> String?
+
+    def shared_facilities_previously_changed?: () -> bool
+
+    def shared_facilities_previous_change: () -> Array[String?]?
+
+    def shared_facilities_previously_was: () -> String?
+
+    def shared_facilities_before_last_save: () -> String?
+
+    def shared_facilities_change_to_be_saved: () -> Array[String?]?
+
+    def shared_facilities_in_database: () -> String?
+
+    def saved_change_to_shared_facilities: () -> Array[String?]?
+
+    def saved_change_to_shared_facilities?: () -> bool
+
+    def will_save_change_to_shared_facilities?: () -> bool
+
+    def restore_shared_facilities!: () -> void
+
+    def clear_shared_facilities_change: () -> void
+
+    def business_entity: () -> String?
+
+    def business_entity=: (String?) -> String?
+
+    def business_entity?: () -> bool
+
+    def business_entity_changed?: () -> bool
+
+    def business_entity_change: () -> [ String?, String? ]
+
+    def business_entity_will_change!: () -> void
+
+    def business_entity_was: () -> String?
+
+    def business_entity_previously_changed?: () -> bool
+
+    def business_entity_previous_change: () -> Array[String?]?
+
+    def business_entity_previously_was: () -> String?
+
+    def business_entity_before_last_save: () -> String?
+
+    def business_entity_change_to_be_saved: () -> Array[String?]?
+
+    def business_entity_in_database: () -> String?
+
+    def saved_change_to_business_entity: () -> Array[String?]?
+
+    def saved_change_to_business_entity?: () -> bool
+
+    def will_save_change_to_business_entity?: () -> bool
+
+    def restore_business_entity!: () -> void
+
+    def clear_business_entity_change: () -> void
+
+    def official_site_url: () -> String?
+
+    def official_site_url=: (String?) -> String?
+
+    def official_site_url?: () -> bool
+
+    def official_site_url_changed?: () -> bool
+
+    def official_site_url_change: () -> [ String?, String? ]
+
+    def official_site_url_will_change!: () -> void
+
+    def official_site_url_was: () -> String?
+
+    def official_site_url_previously_changed?: () -> bool
+
+    def official_site_url_previous_change: () -> Array[String?]?
+
+    def official_site_url_previously_was: () -> String?
+
+    def official_site_url_before_last_save: () -> String?
+
+    def official_site_url_change_to_be_saved: () -> Array[String?]?
+
+    def official_site_url_in_database: () -> String?
+
+    def saved_change_to_official_site_url: () -> Array[String?]?
+
+    def saved_change_to_official_site_url?: () -> bool
+
+    def will_save_change_to_official_site_url?: () -> bool
+
+    def restore_official_site_url!: () -> void
+
+    def clear_official_site_url_change: () -> void
+
+    def created_at: () -> ActiveSupport::TimeWithZone
+
+    def created_at=: (ActiveSupport::TimeWithZone) -> ActiveSupport::TimeWithZone
+
+    def created_at?: () -> bool
+
+    def created_at_changed?: () -> bool
+
+    def created_at_change: () -> [ ActiveSupport::TimeWithZone?, ActiveSupport::TimeWithZone? ]
+
+    def created_at_will_change!: () -> void
+
+    def created_at_was: () -> ActiveSupport::TimeWithZone?
+
+    def created_at_previously_changed?: () -> bool
+
+    def created_at_previous_change: () -> Array[ActiveSupport::TimeWithZone?]?
+
+    def created_at_previously_was: () -> ActiveSupport::TimeWithZone?
+
+    def created_at_before_last_save: () -> ActiveSupport::TimeWithZone?
+
+    def created_at_change_to_be_saved: () -> Array[ActiveSupport::TimeWithZone?]?
+
+    def created_at_in_database: () -> ActiveSupport::TimeWithZone?
+
+    def saved_change_to_created_at: () -> Array[ActiveSupport::TimeWithZone?]?
+
+    def saved_change_to_created_at?: () -> bool
+
+    def will_save_change_to_created_at?: () -> bool
+
+    def restore_created_at!: () -> void
+
+    def clear_created_at_change: () -> void
+
+    def updated_at: () -> ActiveSupport::TimeWithZone
+
+    def updated_at=: (ActiveSupport::TimeWithZone) -> ActiveSupport::TimeWithZone
+
+    def updated_at?: () -> bool
+
+    def updated_at_changed?: () -> bool
+
+    def updated_at_change: () -> [ ActiveSupport::TimeWithZone?, ActiveSupport::TimeWithZone? ]
+
+    def updated_at_will_change!: () -> void
+
+    def updated_at_was: () -> ActiveSupport::TimeWithZone?
+
+    def updated_at_previously_changed?: () -> bool
+
+    def updated_at_previous_change: () -> Array[ActiveSupport::TimeWithZone?]?
+
+    def updated_at_previously_was: () -> ActiveSupport::TimeWithZone?
+
+    def updated_at_before_last_save: () -> ActiveSupport::TimeWithZone?
+
+    def updated_at_change_to_be_saved: () -> Array[ActiveSupport::TimeWithZone?]?
+
+    def updated_at_in_database: () -> ActiveSupport::TimeWithZone?
+
+    def saved_change_to_updated_at: () -> Array[ActiveSupport::TimeWithZone?]?
+
+    def saved_change_to_updated_at?: () -> bool
+
+    def will_save_change_to_updated_at?: () -> bool
+
+    def restore_updated_at!: () -> void
+
+    def clear_updated_at_change: () -> void
+  end
+  include GeneratedAttributeMethods
+
+  def office: () -> Office
+  def office=: (Office?) -> Office?
+  def reload_office: () -> Office?
+  def build_office: (untyped) -> Office
+  def create_office: (untyped) -> Office
+  def create_office!: (untyped) -> Office
+  module GeneratedAssociationMethods
+  end
+  include GeneratedAssociationMethods
+
+  module GeneratedRelationMethods
+  end
+
+  class ActiveRecord_Relation < ::ActiveRecord::Relation
+    include GeneratedRelationMethods
+    include _ActiveRecord_Relation[OfficeOverview, Integer]
+    include Enumerable[OfficeOverview]
+  end
+
+  class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+    include GeneratedRelationMethods
+    include _ActiveRecord_Relation[OfficeOverview, Integer]
+  end
+end

--- a/sig/rbs_rails/path_helpers.rbs
+++ b/sig/rbs_rails/path_helpers.rbs
@@ -16,7 +16,7 @@ interface _RbsRailsPathHelpers
   def new_api_v1_user_confirmation_path: (*untyped) -> String
   def api_v1_user_confirmation_path: (*untyped) -> String
   def api_v1_auth_validate_token_path: (*untyped) -> String
-  def api_v1_tests_path: (*untyped) -> String
+  def api_v1_manager_office_overview_path: (*untyped) -> String
   def letter_opener_web_path: (*untyped) -> String
   def health_check_path: (*untyped) -> String
   def rails_service_blob_path: (*untyped) -> String
@@ -47,7 +47,7 @@ interface _RbsRailsPathHelpers
   def new_api_v1_user_confirmation_url: (*untyped) -> String
   def api_v1_user_confirmation_url: (*untyped) -> String
   def api_v1_auth_validate_token_url: (*untyped) -> String
-  def api_v1_tests_url: (*untyped) -> String
+  def api_v1_manager_office_overview_url: (*untyped) -> String
   def letter_opener_web_url: (*untyped) -> String
   def health_check_url: (*untyped) -> String
   def rails_service_blob_url: (*untyped) -> String

--- a/spec/cassettes/DeviseTokenAuth_Registrations/ユーザー新規作成/ケアマネの場合/Managerの値が無効な属性値の場合_新規登録及びメール送信されないこと.yml
+++ b/spec/cassettes/DeviseTokenAuth_Registrations/ユーザー新規作成/ケアマネの場合/Managerの値が無効な属性値の場合_新規登録及びメール送信されないこと.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://geoapi.heartrails.com/api/json?method=searchByPostal&postal=0010010
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - geoapi.heartrails.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 30 Oct 2022 09:49:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Etag:
+      - '"3188d424ed0b30c904e2c3554e72f7d1"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Runtime:
+      - '0.002157'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"response":{"location":[{"city":"\u672d\u5e4c\u5e02\u5317\u533a","city_kana":"\u3055\u3063\u307d\u308d\u3057\u304d\u305f\u304f","town":"\u5317\u5341\u6761\u897f","town_kana":"\u304d\u305f10\u3058\u3087\u3046\u306b\u3057","x":"141.350427","y":"43.073211","prefecture":"\u5317\u6d77\u9053","postal":"0010010"}]}}'
+  recorded_at: Sun, 30 Oct 2022 09:49:17 GMT
+- request:
+    method: get
+    uri: http://geoapi.heartrails.com/api/json?method=getStations&postal=0010010
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - geoapi.heartrails.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 30 Oct 2022 09:49:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Etag:
+      - '"efb873436bb20f564c85624d34696a4f"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Runtime:
+      - '0.006268'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"response":{"station":[{"name":"\u531712\u6761","kana":"\u304d\u305f\u3058\u3085\u3046\u306b\u3058\u3087\u3046","line":"\u672d\u5e4c\u5e02\u5357\u5317\u7dda","y":43.074829,"x":141.348403,"postal":"0010012","prev":"\u531718\u6761","next":"\u3055\u3063\u307d\u308d","prefecture":"\u5317\u6d77\u9053","distance":243.9856461137282}]}}'
+  recorded_at: Sun, 30 Oct 2022 09:49:17 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/DeviseTokenAuth_Registrations/ユーザー新規作成/ケアマネの場合/有効な属性値の場合_OfficeとOfficeOverviewsも一緒に作成されること.yml
+++ b/spec/cassettes/DeviseTokenAuth_Registrations/ユーザー新規作成/ケアマネの場合/有効な属性値の場合_OfficeとOfficeOverviewsも一緒に作成されること.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://geoapi.heartrails.com/api/json?method=searchByPostal&postal=0010010
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - geoapi.heartrails.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 29 Oct 2022 06:02:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Etag:
+      - '"3188d424ed0b30c904e2c3554e72f7d1"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Runtime:
+      - '0.002958'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"response":{"location":[{"city":"\u672d\u5e4c\u5e02\u5317\u533a","city_kana":"\u3055\u3063\u307d\u308d\u3057\u304d\u305f\u304f","town":"\u5317\u5341\u6761\u897f","town_kana":"\u304d\u305f10\u3058\u3087\u3046\u306b\u3057","x":"141.350427","y":"43.073211","prefecture":"\u5317\u6d77\u9053","postal":"0010010"}]}}'
+  recorded_at: Sat, 29 Oct 2022 06:02:44 GMT
+- request:
+    method: get
+    uri: http://geoapi.heartrails.com/api/json?method=getStations&postal=0010010
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - geoapi.heartrails.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 29 Oct 2022 06:02:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Etag:
+      - '"efb873436bb20f564c85624d34696a4f"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Runtime:
+      - '0.006440'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"response":{"station":[{"name":"\u531712\u6761","kana":"\u304d\u305f\u3058\u3085\u3046\u306b\u3058\u3087\u3046","line":"\u672d\u5e4c\u5e02\u5357\u5317\u7dda","y":43.074829,"x":141.348403,"postal":"0010012","prev":"\u531718\u6761","next":"\u3055\u3063\u307d\u308d","prefecture":"\u5317\u6d77\u9053","distance":243.9856461137282}]}}'
+  recorded_at: Sat, 29 Oct 2022 06:02:44 GMT
+recorded_with: VCR 6.1.0

--- a/spec/factories/office_overviews.rb
+++ b/spec/factories/office_overviews.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :office_overview do
+    office
+    classify { '介護付きホーム（サービス付き高齢者向け住宅　特定施設）' }
+    opening_date { '2022-3-11' }
+    room_count { 30 }
+    requirements { '満60歳以上の方、入居時自立・要支援・要介護' }
+    shared_facilities { 'エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園' }
+    business_entity { '株式会社ユニマット　リタイアメント・コミュニティ' }
+    official_site_url { 'https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html' }
+  end
+end

--- a/spec/models/office_overview_spec.rb
+++ b/spec/models/office_overview_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe OfficeOverview, type: :model do
+  describe 'バリデーション' do
+    context '関連付け' do
+      it { is_expected.to belong_to(:office) }
+
+      it do
+        create(:office_overview)
+        expect(subject).to validate_uniqueness_of(:office_id)
+      end
+
+      it '親を削除しないと、削除できないこと' do
+        office_overview = create(:office_overview)
+        office_overview.destroy
+        expect(office_overview.errors.full_messages[0]).to eq 'このモデルのみを削除することはできません。削除する場合は、親を削除してください。'
+      end
+    end
+
+    context 'official_site_url' do
+      let(:office_overview) { build(:office_overview) }
+
+      it 'フォーマットがURLの場合、有効であること' do
+        office_overview.official_site_url = 'https://www.unimat-rc.co.jp/shisetsu/sosigaya_871/index.html'
+        expect(office_overview.valid?).to be true
+      end
+
+      it 'フォーマットがURLではない場合、無効であること' do
+        office_overview.official_site_url = 'hoge'
+        expect(office_overview.valid?).to be false
+      end
+
+      it 'nilの場合は有効であること' do
+        office_overview.official_site_url = nil
+        expect(office_overview.valid?).to be true
+      end
+    end
+  end
+end

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -2,12 +2,19 @@ require 'rails_helper'
 
 RSpec.describe Office, type: :model do
   describe 'バリデーション' do
-    context 'manager_id' do
+    context '関連付け' do
       it { is_expected.to belong_to(:manager) }
+      it { is_expected.to have_one(:office_overview).dependent(:destroy) }
 
       it do
         create(:office)
         expect(subject).to validate_uniqueness_of(:manager_id)
+      end
+
+      it '親を削除しないと、削除できないこと' do
+        office = create(:office)
+        office.destroy
+        expect(office.errors.full_messages[0]).to eq 'このモデルのみを削除することはできません。削除する場合は、親を削除してください。'
       end
     end
 

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe Office, type: :model do
 
     context 'name' do
       it { is_expected.to validate_presence_of(:name) }
-      it { is_expected.to validate_length_of(:name).is_at_most(100) }
+      it { is_expected.to validate_length_of(:name).is_at_most(200) }
     end
 
     context 'feature_title' do
       it { is_expected.to validate_presence_of(:feature_title) }
-      it { is_expected.to validate_length_of(:feature_title).is_at_most(100) }
+      it { is_expected.to validate_length_of(:feature_title).is_at_most(200) }
     end
 
     context 'feature_detail' do

--- a/spec/requests/api/v1/manager/office_overviews_spec.rb
+++ b/spec/requests/api/v1/manager/office_overviews_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Manager::OfficeOverviews', type: :request do
+  describe 'GET /api/v1/manager/office_overview' do
+    let!(:office_overview) { create(:office_overview) }
+    let(:manager) { office_overview.office.manager }
+    let(:client) { create(:client) }
+
+    it 'ケアマネでログインした場合、施設概要を取得できること' do
+      login manager
+      get api_v1_manager_office_overview_path
+      assert_response_schema_confirm(200)
+    end
+
+    it 'ログインしていない場合、エラーが返ってくること' do
+      get api_v1_manager_office_overview_path
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'クライアントでログインした場合、エラーが返ってくること' do
+      login client
+      get api_v1_manager_office_overview_path
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'PATCH /api/v1/manager/office_overview' do
+    let!(:office_overview) { create(:office_overview) }
+    let(:manager) { office_overview.office.manager }
+    let(:client) { create(:client) }
+    let(:new_params) do
+      attrs = office_overview.attributes
+      attrs[:classify] = '類型アップデート'
+      attrs
+    end
+    let(:req) { patch api_v1_manager_office_overview_path, params: new_params }
+
+    it 'ケアマネでログインした場合、施設概要を更新できること' do
+      pp described_class
+      login manager
+      expect do
+        patch api_v1_manager_office_overview_path, params: new_params
+        office_overview.reload
+      end.to change(office_overview, :classify).to('類型アップデート')
+      assert_response_schema_confirm(200)
+    end
+
+    it 'ログインしていない場合、エラーが返ってくること' do
+      patch api_v1_manager_office_overview_path, params: new_params
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'クライアントでログインした場合、エラーが返ってくること' do
+      login client
+      patch api_v1_manager_office_overview_path, params: new_params
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it '無効な値の場合、エラーレスポンスが返ってくること' do
+      new_params[:classify] = 'a' * 201
+      login manager
+      patch api_v1_manager_office_overview_path, params: new_params
+      assert_response_schema_confirm(400)
+    end
+  end
+end

--- a/spec/requests/devise_token_auth/registrations_spec.rb
+++ b/spec/requests/devise_token_auth/registrations_spec.rb
@@ -33,15 +33,17 @@ RSpec.describe 'DeviseTokenAuth::Registrations', type: :request do
         attributes_for(:manager, confirm_success_url: 'test1@example.com')
       end
 
-      it '有効な属性値の場合、Officeも一緒に作成されること', vcr: true do
+      it '有効な属性値の場合、OfficeとOfficeOverviewsも一緒に作成されること', vcr: true do
         expect(Manager.count).to eq(0)
         expect(Office.count).to eq(0)
+        expect(OfficeOverview.count).to eq(0)
         expect(ActionMailer::Base.deliveries.count).to eq(0)
 
         post api_v1_user_registration_path, params: manager_params
 
         expect(Manager.count).to eq(1)
         expect(Office.count).to eq(1)
+        expect(OfficeOverview.count).to eq(1)
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         assert_response_schema_confirm(200)
       end


### PR DESCRIPTION
## チケット
#81 

resolve #78
resolve #79

## やったこと
施設概要となるOfficeOverviewモデルの作成、及び詳細、編集のエンドポイントを追加しました。フロントで言うところの👇になります
![image](https://user-images.githubusercontent.com/68116815/198879037-5384fb74-6313-4d03-a271-4111e7426885.png)


テーブル定義　https://docs.google.com/spreadsheets/d/1pJFW2kaZKHL6hyU_IcHavuRGsfmVOI3U9zly_LjZBU8/edit#gid=1754422801

## OpenAPI
- [施設概要詳細](https://rahhi555.stoplight.io/docs/home-care-navi-second/b9f6541518390-)
- [施設概要更新](https://rahhi555.stoplight.io/docs/home-care-navi-second/69c39c546488f-)

## 備考
この施設概要のモデルはフロント的にもテーブル的にも、ひとかたまりとなっていて実装しやすかったため、まずは一旦これを作成しました。
