### PR TITLE
エリア検索機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'devise_token_auth', '>= 1.2.0', git: 'https://github.com/lynndylanhurley/de
 gem 'discard', '~> 1.2'
 gem 'enum_help'
 gem 'image_processing'
+gem 'jb'
+gem 'kaminari'
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
 gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,9 +162,22 @@ GEM
     io-console (0.5.11)
     irb (1.4.2)
       reline (>= 0.3.0)
+    jb (0.8.0)
     jmespath (1.6.1)
     json (2.6.2)
     json_schema (0.21.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.1)
     launchy (2.5.0)
       addressable (~> 2.7)
@@ -372,6 +385,8 @@ DEPENDENCIES
   faker
   gimei
   image_processing
+  jb
+  kaminari
   letter_opener_web (~> 2.0)
   pg (~> 1.1)
   puma (~> 5.0)

--- a/Steepfile
+++ b/Steepfile
@@ -14,10 +14,10 @@ target :lib do
   # library "strong_json"           # Gems
 
   # configure_code_diagnostics(D::Ruby.strict)       # `strict` diagnostics setting
-  configure_code_diagnostics(D::Ruby.lenient)      # `lenient` diagnostics setting
-  configure_code_diagnostics do |hash|             # You can setup everything yourself
+  # configure_code_diagnostics(D::Ruby.lenient)      # `lenient` diagnostics setting
+  configure_code_diagnostics do |hash| # You can setup everything yourself
+    hash[D::Ruby::NoMethod] = :hint
     hash[D::Ruby::UnsupportedSyntax] = :hint
-    hash[D::Ruby::UnresolvedOverloading] = :hint
     hash[D::Ruby::UnexpectedBlockGiven] = :hint
   end
 end

--- a/app/controllers/api/v1/client/offices_controller.rb
+++ b/app/controllers/api/v1/client/offices_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V1
+    module Client
+      class OfficesController < ApplicationController
+        before_action :authenticate_api_v1_client!
+
+        def area_search
+          @result = Office.search_by_area(params[:q]).page(params[:page])
+          render template: 'api/v1/client/offices/search_result', status: :ok
+        end
+      end
+    end
+  end
+end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -16,4 +16,18 @@ class Office < ApplicationRecord
   validates :nearest_station, presence: true
 
   flag :workday, %i[sun mon tue wed thu fri sat]
+
+  # アドレスによる前方一致検索を実行する
+  # @param [String] area 都道府県及び市区町村
+  # @example
+  #   Office.search_by_area("東京都新宿区市谷")
+  scope :search_by_area, lambda { |area|
+    eager_load(:manager, :office_images)
+      .where(
+        'users.address LIKE ?',
+        # 参考: https://railsguides.jp/active_record_querying.html#%E6%9D%A1%E4%BB%B6%E3%81%A7like%E3%82%92%E4%BD%BF%E3%81%86
+        "#{sanitize_sql_like(area)}%"
+      )
+      .order(:created_at)
+  }
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -22,7 +22,7 @@ class Office < ApplicationRecord
   # @example
   #   Office.search_by_area("東京都新宿区市谷")
   scope :search_by_area, lambda { |area|
-    eager_load(:manager, :office_images)
+    eager_load(:manager, { office_images: { image_attachment: :blob } })
       .where(
         'users.address LIKE ?',
         # 参考: https://railsguides.jp/active_record_querying.html#%E6%9D%A1%E4%BB%B6%E3%81%A7like%E3%82%92%E4%BD%BF%E3%81%86

--- a/app/views/api/v1/client/offices/search_result.json.jb
+++ b/app/views/api/v1/client/offices/search_result.json.jb
@@ -1,0 +1,20 @@
+offices = @result.map do |office|
+  {
+    id: office.id,
+    name: office.name,
+    nearest_station: office.nearest_station,
+    stuff_count: 10, # TODO: スタッフの人数は後から追加
+    is_bookmark: false, # TODO: 余裕があればブックマーク機能追加
+    tel: office.manager.tel,
+    feature_title: office.feature_title,
+    workday: office.workday,
+    thumbnail_image: office.office_images.find(&:thumbnail?)&.image_url
+  }
+end
+
+paginate = render partial: 'api/v1/shared/paginate'
+
+{
+  offices:,
+  paginate:
+}

--- a/app/views/api/v1/shared/_paginate.json.jb
+++ b/app/views/api/v1/shared/_paginate.json.jb
@@ -1,0 +1,6 @@
+{
+  current_page: @result.current_page,
+  prev_page: @result.prev_page,
+  next_page: @result.next_page,
+  total_page: @result.total_pages
+}

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,11 @@ Rails.application.routes.draw do
       end
 
       namespace :client do
+        resources :offices, only: [:show] do
+          collection do
+            get :area_search, to: :area_search
+          end
+        end
       end
     end
   end

--- a/home-care-navi-second-open-api.yaml
+++ b/home-care-navi-second-open-api.yaml
@@ -757,30 +757,32 @@ paths:
         - $ref: '#/components/parameters/access-token'
         - $ref: '#/components/parameters/client'
         - $ref: '#/components/parameters/uid'
-  /api/v1/client/offices/area:
+  /api/v1/client/offices/area_search:
     get:
       summary: 事業所エリア検索(事業所利用者)
       tags:
         - office
-      operationId: getClientOfficesArea
-      description: 事業所一覧を取得する。住所で絞り込む。
+      operationId: getClientOfficesAreaSearch
+      description: 事業所一覧をエリア検索する
       parameters:
         - schema:
             type: string
-            example: 東京 大阪 群馬
+            example: 札幌市北区北十条西
           in: query
           name: q
-          description: addressを前方一致検索する。OR検索は半角スペースで区切る。
+          description: エリアの文字列
+          required: true
         - schema:
-            type: string
+            type: integer
+            example: 2
           in: query
           name: page
-          description: ページネーション
+          description: 要求するページ番号。この項目が無い場合は自動的に1ページ目が返ってくる
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/SearchResult'
     parameters: []
-  /api/v1/client/offices/search:
+  /api/v1/client/offices/word_search:
     get:
       summary: 事業所全文一致検索(事業所利用者)
       tags:
@@ -790,20 +792,22 @@ paths:
       parameters:
         - schema:
             type: string
-            example: 東京 大阪 群馬
+            example: 祖師谷ケアパーク
           in: query
           name: q
-          description: addressを全文検索する。OR検索は半角スペースで区切る。
+          description: 検索単語
+          required: true
         - schema:
-            type: string
+            type: integer
+            example: 2
           in: query
           name: page
-          description: ページネーション
+          description: 要求するページ番号。この項目が無い場合は自動的に1ページ目が返ってくる
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/SearchResult'
     parameters: []
-  /api/v1/client/offices/nearest:
+  /api/v1/client/offices/nearest_search:
     get:
       summary: 事業所現在地検索(事業所利用者)
       tags:
@@ -816,19 +820,22 @@ paths:
           in: query
           name: lat
           description: 緯度
+          required: true
         - schema:
             type: number
           in: query
           name: lng
           description: 経度
+          required: true
         - schema:
-            type: string
+            type: integer
+            example: 2
           in: query
           name: page
-          description: ページネーション
+          description: 要求するページ番号。この項目が無い場合は自動的に1ページ目が返ってくる
       responses:
         '200':
-          description: OK
+          $ref: '#/components/responses/SearchResult'
     parameters: []
   '/api/v1/client/office/{id}':
     get:
@@ -1490,6 +1497,34 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  office_id:
+                    type: integer
+                  name:
+                    type: string
+                  furigana:
+                    type: string
+                  introduction:
+                    type: string
+                  role:
+                    type: integer
+              examples:
+                Example 1:
+                  value:
+                    - office_id: 1
+                      name: サンプル太郎
+                      furigana: さんぷるたろう
+                      introduction: ここにスタッフの説明がはいります
+                      role: 0
+                    - office_id: 2
+                      name: サンプル太郎2
+                      furigana: さんぷるたろうに
+                      introduction: ここにスタッフの説明がはいります
+                      role: 1
       operationId: getManagerStaffs
       tags:
         - staff
@@ -1898,6 +1933,43 @@ components:
         - furigana
         - introduction
         - role
+    Paginate:
+      title: Paginate
+      x-stoplight:
+        id: bebxbyo6jawmb
+      type: object
+      description: ページネーションのレスポンス
+      x-examples:
+        Example 1:
+          current_page: 2
+          prev_page: null
+          next_page: 2
+          total_page: 10
+      additionalProperties: false
+      properties:
+        current_page:
+          type: integer
+          description: 現在のページ
+          example: 2
+        prev_page:
+          type: integer
+          description: 前のページ
+          example: null
+          nullable: true
+        next_page:
+          type: integer
+          example: 2
+          description: 次のページ
+          nullable: true
+        total_page:
+          type: integer
+          example: 10
+          description: 総ページ数
+      required:
+        - current_page
+        - prev_page
+        - next_page
+        - total_page
   responses:
     AuthSuccess:
       description: ''
@@ -1916,7 +1988,7 @@ components:
             required:
               - data
           examples:
-            Example 1:
+            example-1:
               value:
                 status: success
                 data:
@@ -1969,6 +2041,111 @@ components:
                   - 類型は200文字以内で入力してください
             required:
               - errors
+    SearchResult:
+      description: エリア検索、現在地検索、単語検索のレスポンス
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            properties:
+              offices:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    id:
+                      type: integer
+                      description: 事業所のid
+                      example: 1
+                    name:
+                      type: string
+                      example: 祖師谷ホームケアそよ風
+                      description: 事業所名
+                    nearest_station:
+                      type: string
+                      example: 札幌市南北線 北12条駅
+                      description: 最寄り駅
+                    stuff_count:
+                      type: integer
+                      example: 30
+                      description: 事業所に所属しているスタッフの総人数
+                    is_bookmark:
+                      type: boolean
+                      default: false
+                      description: 現在のユーザーがこの事務所をブックマークしているかどうか
+                    tel:
+                      type: string
+                      example: 事業所の電話番号
+                      description: 080-2916-9802
+                    feature_title:
+                      type: string
+                      example: 事業所紹介タイトル
+                      description: 事業所紹介タイトル
+                    workday:
+                      type: array
+                      example:
+                        - mon
+                        - tue
+                        - wed
+                        - thu
+                        - fri
+                      description: 営業曜日
+                      items:
+                        type: string
+                        enum:
+                          - sun
+                          - mon
+                          - tue
+                          - wed
+                          - thu
+                          - fri
+                          - sat
+                    thumbnail_image:
+                      type: string
+                      format: uri
+                      example: 'http://localhost:3000/rails/active_storage/disk/eyJfcmF/test_image.jpg'
+                      description: サムネイルのイメージ画像
+                      nullable: true
+                  required:
+                    - id
+                    - name
+                    - nearest_station
+                    - stuff_count
+                    - is_bookmark
+                    - tel
+                    - feature_title
+                    - workday
+                    - thumbnail_image
+              paginate:
+                $ref: '#/components/schemas/Paginate'
+            required:
+              - offices
+              - paginate
+          examples:
+            Example 1:
+              value:
+                offices:
+                  - id: 1
+                    name: 祖師谷ホームケアそよ風
+                    nearest_station: 札幌市南北線 北12条駅
+                    stuff_count: 30
+                    is_bookmark: false
+                    tel: 事業所の電話番号
+                    feature_title: 事業所紹介タイトル
+                    workday:
+                      - mon
+                      - tue
+                      - wed
+                      - thu
+                      - fri
+                    thumbnail_image: 'http://localhost:3000/rails/active_storage/disk/eyJfcmF/test_image.jpg'
+                paginate:
+                  current_page: 2
+                  prev_page: null
+                  next_page: 2
+                  total_page: 10
   requestBodies: {}
   parameters:
     access-token:

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -55,7 +55,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -63,7 +63,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activejob
@@ -71,7 +71,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activemodel
@@ -79,7 +79,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activerecord
@@ -87,7 +87,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activestorage
@@ -95,7 +95,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -103,7 +103,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -111,7 +111,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-core
@@ -119,7 +119,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-kms
@@ -127,7 +127,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: aws-sdk-s3
@@ -135,7 +135,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: bcrypt
@@ -143,7 +143,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -155,7 +155,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: fileutils
@@ -167,7 +167,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: io-console
@@ -178,12 +178,20 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: kaminari-core
+  version: '1.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: listen
   version: '3.2'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mail
@@ -191,7 +199,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: minitest
@@ -203,7 +211,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parallel
@@ -211,7 +219,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rack
@@ -219,7 +227,15 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rails-dom-testing
+  version: '2.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: railties
@@ -227,7 +243,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rainbow
@@ -235,7 +251,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 8dd219de2f8f224db427607ce65b448961467418
+    revision: 0a45b6d56b0e1b089731f5eb007912a7c36be121
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rbs_rails

--- a/sig/app/controllers/api/v1/client/offices_controller.rbs
+++ b/sig/app/controllers/api/v1/client/offices_controller.rbs
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    module Client
+      class OfficesController < ApplicationController
+        @result: Office::ActiveRecord_Relation
+        def area_search: () -> void
+      end
+    end
+  end
+end

--- a/sig/app/models/office.rbs
+++ b/sig/app/models/office.rbs
@@ -2,4 +2,12 @@ class Office < ApplicationRecord
   extend ActiveFlag::ClassMethods
   def workday: () -> ActiveFlag::Value
   def self.workdays: () -> ActiveFlag::Definition
+  
+  # kaminariによるページネーション
+  def self.page: (Integer?) -> Office::ActiveRecord_Relation
+               
+  class ActiveRecord_Relation < ::ActiveRecord::Relation
+    include Kaminari::PageScopeMethods
+    def page: (Integer?) -> Office::ActiveRecord_Relation
+  end
 end

--- a/sig/rbs_rails/app/models/office.rbs
+++ b/sig/rbs_rails/app/models/office.rbs
@@ -491,7 +491,10 @@ class Office < ::ApplicationRecord
   end
   include GeneratedAssociationMethods
 
+  def self.search_by_area: (untyped area) -> ActiveRecord_Relation
+
   module GeneratedRelationMethods
+    def search_by_area: (untyped area) -> ActiveRecord_Relation
   end
 
   class ActiveRecord_Relation < ::ActiveRecord::Relation

--- a/sig/rbs_rails/path_helpers.rbs
+++ b/sig/rbs_rails/path_helpers.rbs
@@ -20,6 +20,8 @@ interface _RbsRailsPathHelpers
   def api_v1_manager_office_overview_path: (*untyped) -> String
   def api_v1_manager_office_images_path: (*untyped) -> String
   def api_v1_manager_office_image_path: (*untyped) -> String
+  def area_search_api_v1_client_offices_path: (*untyped) -> String
+  def api_v1_client_office_path: (*untyped) -> String
   def letter_opener_web_path: (*untyped) -> String
   def health_check_path: (*untyped) -> String
   def rails_service_blob_path: (*untyped) -> String
@@ -54,6 +56,8 @@ interface _RbsRailsPathHelpers
   def api_v1_manager_office_overview_url: (*untyped) -> String
   def api_v1_manager_office_images_url: (*untyped) -> String
   def api_v1_manager_office_image_url: (*untyped) -> String
+  def area_search_api_v1_client_offices_url: (*untyped) -> String
+  def api_v1_client_office_url: (*untyped) -> String
   def letter_opener_web_url: (*untyped) -> String
   def health_check_url: (*untyped) -> String
   def rails_service_blob_url: (*untyped) -> String

--- a/spec/factories/managers.rb
+++ b/spec/factories/managers.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     name { Gimei.name.kanji }
     email { Faker::Internet.safe_email }
     tel { Faker::PhoneNumber.cell_phone }
-    address { '札幌市北区北十条西' }
+    address { '北海道札幌市北区北十条西' }
     postal { '0010010' }
     password { Faker::Internet.password }
     type { 'Manager' }

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -53,4 +53,40 @@ RSpec.describe Office do
       it { is_expected.to validate_presence_of(:nearest_station) }
     end
   end
+
+  describe 'search_by_areaメソッド' do
+    before do
+      manager_tokyo1 = create(:manager, address: '東京都港区芝浦１丁目１−１')
+      create(:office, manager: manager_tokyo1)
+
+      manager_tokyo2 = create(:manager, address: '東京都新宿区西新宿１丁目１−１')
+      create(:office, manager: manager_tokyo2)
+
+      manager_ibaraki = create(:manager, address: '茨城県水戸市中央１丁目１−１')
+      create(:office, manager: manager_ibaraki)
+    end
+
+    it '東京都で検索した場合、２件返ってくること' do
+      search_result = Office.search_by_area('東京都')
+      expect(search_result.count).to eq(2)
+      expect(search_result.pluck(:address)).to be_all { |address| address.start_with?('東京都') }
+    end
+
+    it '東京都港区で検索した場合、１件返ってくること' do
+      search_result = Office.search_by_area('東京都港区')
+      expect(search_result.count).to eq(1)
+      expect(search_result.pluck(:address)).to be_all { |address| address.start_with?('東京都港区') }
+    end
+
+    it '茨城県で検索した場合、１件返ってくること' do
+      search_result = Office.search_by_area('茨城県')
+      expect(search_result.count).to eq(1)
+      expect(search_result.pluck(:address)).to be_all { |address| address.start_with?('茨城県') }
+    end
+
+    it 'いずれも一致しない文字列で検索した場合、０件返ってくること' do
+      search_result = Office.search_by_area('神奈川県')
+      expect(search_result.count).to eq(0)
+    end
+  end
 end

--- a/spec/requests/api/v1/client/offices_spec.rb
+++ b/spec/requests/api/v1/client/offices_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Client::Offices' do
+  # このテストでは主にページネーション等のAPI特有の挙動をテストするため、
+  # 正しく前方一致検索出来ているかのようなロジックはテストしない。検索ロジックのテストはOfficeモデルスペックに記述済み。
+
+  describe 'GET /api/v1/client/offices/area' do
+    context 'クライアントでログインした場合' do
+      # ページネーションは10件単位なので、11件作成し2ページの挙動をテストできるようにする
+      let!(:offices) { create_list(:office, 11) }
+      let(:q) { offices.first.manager.address }
+      let!(:client) { create(:client) }
+
+      it 'クエリパラメータにpageが存在しない場合、1ページ目かつ10件の事業所が返ってくること' do
+        login client
+        get area_search_api_v1_client_offices_path, params: { q: }
+        response_symbolized_body => { offices:, paginate: }
+        expect(paginate[:current_page]).to eq 1
+        expect(offices.length).to eq 10
+        assert_response_schema_confirm(200)
+      end
+
+      it 'クエリパラメータのpageに2を指定した場合、2ページ目かつ1件の事業所が返ってくること' do
+        login client
+        get area_search_api_v1_client_offices_path, params: { q:, page: 2 }
+        response_symbolized_body => { offices:, paginate: }
+        expect(paginate[:current_page]).to eq 2
+        expect(offices.length).to eq 1
+        assert_response_schema_confirm(200)
+      end
+    end
+
+    it 'ログインしていない場合、エラーが返ってくること' do
+      get area_search_api_v1_client_offices_path
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'ケアマネでログインした場合、エラーが返ってくること' do
+      manager = create(:manager)
+      login manager
+      get area_search_api_v1_client_offices_path
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/requests/api/v1/client/offices_spec.rb
+++ b/spec/requests/api/v1/client/offices_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Client::Offices' do
-  # このテストでは主にページネーション等のAPI特有の挙動をテストするため、
-  # 正しく前方一致検索出来ているかのようなロジックはテストしない。検索ロジックのテストはOfficeモデルスペックに記述済み。
-
   describe 'GET /api/v1/client/offices/area' do
     context 'クライアントでログインした場合' do
-      # ページネーションは10件単位なので、11件作成し2ページの挙動をテストできるようにする
-      let!(:offices) { create_list(:office, 11) }
-      let(:q) { offices.first.manager.address }
+      before do
+        # ページネーションは10件単位なので、11件作成し2ページの挙動をテストできるようにする
+        create_list(:office_image, 11)
+        Manager.update_all(address: '北海道札幌市北区北十条西3-23-1')
+      end
+
       let!(:client) { create(:client) }
 
       it 'クエリパラメータにpageが存在しない場合、1ページ目かつ10件の事業所が返ってくること' do
         login client
-        get area_search_api_v1_client_offices_path, params: { q: }
+        get area_search_api_v1_client_offices_path, params: { q: '北海道札幌市北区' }
         response_symbolized_body => { offices:, paginate: }
         expect(paginate[:current_page]).to eq 1
         expect(offices.length).to eq 10
@@ -22,7 +22,7 @@ RSpec.describe 'Api::V1::Client::Offices' do
 
       it 'クエリパラメータのpageに2を指定した場合、2ページ目かつ1件の事業所が返ってくること' do
         login client
-        get area_search_api_v1_client_offices_path, params: { q:, page: 2 }
+        get area_search_api_v1_client_offices_path, params: { q: '北海道札幌市北区', page: 2 }
         response_symbolized_body => { offices:, paginate: }
         expect(paginate[:current_page]).to eq 2
         expect(offices.length).to eq 1


### PR DESCRIPTION
## チケット
#60 

## やったこと
- エリア検索機能追加

## できるようになること（ユーザ目線）
- エリア検索ができるようになる

## OpenAPI
- https://rahhi555.stoplight.io/docs/home-care-navi-second/d45ff3a9e2b72-

## 備考
今回のプルリクエストで以下の２つのgemを追加しています

- [kaminari](https://github.com/kaminari/kaminari)
  - ページネーション用のgem
- [jb](https://github.com/amatsuda/jb)
  - jsonシリアライズ用のgem

`kaminari`に関してはページネーションする上でほぼ必須なのですが、`jb`に関してはどうしても必要というものではございません。
新しくgemを追加することによる管理の煩雑化や、学習コストがございますので、使用したくないという場合はご意見ください。
また、過去に`jb`以外のgemを使用したことがあれば、そちらに合わせたいと思うのでお声がけください。
Slackでjsonシリアライザー導入の有無について質問させていただきましたが、実際に使用されているコードを見てみないとイメージが湧きにくいと思ったので、一応プルリクエストを上げました。
リジェクト前提ですので、反対の場合は遠慮なくご申付ください。