### PR TITLE
Fix: 検索結果に総件数追加及びエンドポイント微修正

### DIFF
--- a/app/controllers/api/v1/client/offices_controller.rb
+++ b/app/controllers/api/v1/client/offices_controller.rb
@@ -7,7 +7,7 @@ module Api
         end
 
         def area_search
-          areas = params[:q].split(',')
+          areas = params[:areas].split(',')
           @result = Office.search_by_area(areas).page(params[:page])
           render template: 'api/v1/client/offices/search_result', status: :ok
         end
@@ -18,7 +18,7 @@ module Api
         end
 
         def word_search
-          @result = Office.search_by_word(params[:q]).page(params[:page])
+          @result = Office.search_by_word(params[:words]).page(params[:page])
           render template: 'api/v1/client/offices/search_result', status: :ok
         end
       end

--- a/app/views/api/v1/shared/_paginate.json.jbuilder
+++ b/app/views/api/v1/shared/_paginate.json.jbuilder
@@ -2,6 +2,7 @@ paginate = {
   current_page: @result.current_page,
   prev_page: @result.prev_page,
   next_page: @result.next_page,
-  total_page: @result.total_pages
+  total_page: @result.total_pages,
+  total_count: @result.total_count
 }
 json.set! :paginate, paginate

--- a/home-care-navi-second-open-api.yaml
+++ b/home-care-navi-second-open-api.yaml
@@ -767,11 +767,12 @@ paths:
       parameters:
         - schema:
             type: string
-            example: 札幌市北区北十条西
+            example: '札幌市北区北十条西,東京都新宿区市谷本村町'
           in: query
-          name: q
-          description: エリアの文字列
+          name: areas
+          description: エリアの文字列。カンマで区切る。
           required: true
+          explode: true
         - schema:
             type: integer
             example: 2
@@ -794,7 +795,7 @@ paths:
             type: string
             example: 祖師谷ケアパーク
           in: query
-          name: q
+          name: words
           description: 検索単語
           required: true
         - schema:
@@ -1948,8 +1949,13 @@ paths:
                       type: string
                       format: binary
                       description: 画像のバイナリデータ
+                    staff_id:
+                      type: integer
+                      example: 1
+                      description: 担当スタッフのid
                   required:
                     - avatar
+                    - staff_id
             examples:
               Example 1:
                 value:
@@ -1960,6 +1966,7 @@ paths:
                   family: 娘
                   age: 40
                   avatar: string
+                  staff_id: 1
         description: ※画像はContentTypeがapplication/jsonでは送信出来ないため、multipart/form-dataかつformDataでラップして送信すること
   '/api/v1/manager/office_clients/{id}':
     patch:
@@ -2421,6 +2428,7 @@ components:
           prev_page: null
           next_page: 2
           total_page: 10
+          total_count: 100
       additionalProperties: false
       properties:
         current_page:
@@ -2441,11 +2449,16 @@ components:
           type: integer
           example: 10
           description: 総ページ数
+        total_count:
+          type: integer
+          description: 対象モデルの総レコード数
+          example: 100
       required:
         - current_page
         - prev_page
         - next_page
         - total_page
+        - total_count
     OfficeClient:
       title: OfficeClient
       x-stoplight:
@@ -2496,6 +2509,94 @@ components:
         - address
         - family
         - age
+    ResponseSearchOffice:
+      title: ResponseSearchOffice
+      x-stoplight:
+        id: v63lkfb1fpxj3
+      type: object
+      additionalProperties: false
+      description: 検索の事業所結果
+      properties:
+        id:
+          type: integer
+          description: 事業所のid
+          example: 1
+        name:
+          type: string
+          example: 祖師谷ホームケアそよ風
+          description: 事業所名
+        nearest_station:
+          type: string
+          example: 札幌市南北線 北12条駅
+          description: 最寄り駅
+        stuff_count:
+          type: integer
+          example: 30
+          description: 事業所に所属しているスタッフの総人数
+        is_bookmark:
+          type: boolean
+          default: false
+          description: 現在のユーザーがこの事務所をブックマークしているかどうか
+        tel:
+          type: string
+          example: 事業所の電話番号
+          description: 080-2916-9802
+        feature_title:
+          type: string
+          example: 事業所紹介タイトル
+          description: 事業所紹介タイトル
+        workday:
+          type: array
+          example:
+            - mon
+            - tue
+            - wed
+            - thu
+            - fri
+          description: 営業曜日
+          items:
+            type: string
+            enum:
+              - sun
+              - mon
+              - tue
+              - wed
+              - thu
+              - fri
+              - sat
+        thumbnail_image:
+          type: string
+          format: uri
+          example: 'http://localhost:3000/rails/active_storage/disk/eyJfcmF/test_image.jpg'
+          description: サムネイルのイメージ画像
+          nullable: true
+      required:
+        - id
+        - name
+        - nearest_station
+        - stuff_count
+        - is_bookmark
+        - tel
+        - feature_title
+        - workday
+        - thumbnail_image
+  x-examples:
+    Example 1:
+      offices:
+        - id: 1
+          name: 祖師谷ホームケアそよ風
+          nearest_station: 札幌市南北線 北12条駅
+          stuff_count: 30
+          is_bookmark: false
+          tel: 事業所の電話番号
+          feature_title: 事業所紹介タイトル
+          workday:
+            - mon
+            - tue
+            - wed
+            - thu
+            - fri
+          thumbnail_image: 'http://localhost:3000/rails/active_storage/disk/eyJfcmF/test_image.jpg'
   responses:
     AuthSuccess:
       description: ''
@@ -2578,72 +2679,7 @@ components:
               offices:
                 type: array
                 items:
-                  type: object
-                  additionalProperties: false
-                  properties:
-                    id:
-                      type: integer
-                      description: 事業所のid
-                      example: 1
-                    name:
-                      type: string
-                      example: 祖師谷ホームケアそよ風
-                      description: 事業所名
-                    nearest_station:
-                      type: string
-                      example: 札幌市南北線 北12条駅
-                      description: 最寄り駅
-                    stuff_count:
-                      type: integer
-                      example: 30
-                      description: 事業所に所属しているスタッフの総人数
-                    is_bookmark:
-                      type: boolean
-                      default: false
-                      description: 現在のユーザーがこの事務所をブックマークしているかどうか
-                    tel:
-                      type: string
-                      example: 事業所の電話番号
-                      description: 080-2916-9802
-                    feature_title:
-                      type: string
-                      example: 事業所紹介タイトル
-                      description: 事業所紹介タイトル
-                    workday:
-                      type: array
-                      example:
-                        - mon
-                        - tue
-                        - wed
-                        - thu
-                        - fri
-                      description: 営業曜日
-                      items:
-                        type: string
-                        enum:
-                          - sun
-                          - mon
-                          - tue
-                          - wed
-                          - thu
-                          - fri
-                          - sat
-                    thumbnail_image:
-                      type: string
-                      format: uri
-                      example: 'http://localhost:3000/rails/active_storage/disk/eyJfcmF/test_image.jpg'
-                      description: サムネイルのイメージ画像
-                      nullable: true
-                  required:
-                    - id
-                    - name
-                    - nearest_station
-                    - stuff_count
-                    - is_bookmark
-                    - tel
-                    - feature_title
-                    - workday
-                    - thumbnail_image
+                  $ref: '#/components/schemas/ResponseSearchOffice'
               paginate:
                 $ref: '#/components/schemas/Paginate'
             required:
@@ -2672,6 +2708,7 @@ components:
                   prev_page: null
                   next_page: 2
                   total_page: 10
+                  total_count: 100
   requestBodies: {}
   parameters:
     access-token:

--- a/spec/requests/api/v1/client/offices_spec.rb
+++ b/spec/requests/api/v1/client/offices_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Api::V1::Client::Offices' do
 
     it 'クエリパラメータにpageが存在しない場合、1ページ目かつ10件の事業所が返ってくること' do
       login client
-      get area_search_api_v1_client_offices_path, params: { q: '北海道札幌市北区' }
+      get area_search_api_v1_client_offices_path, params: { areas: '北海道札幌市北区' }
       response_symbolized_body => { offices:, paginate: }
       expect(paginate[:current_page]).to eq 1
       expect(offices.length).to eq 10
@@ -32,7 +32,7 @@ RSpec.describe 'Api::V1::Client::Offices' do
 
     it 'クエリパラメータのpageに2を指定した場合、2ページ目かつ1件の事業所が返ってくること' do
       login client
-      get area_search_api_v1_client_offices_path, params: { q: '北海道札幌市北区', page: 2 }
+      get area_search_api_v1_client_offices_path, params: { areas: '北海道札幌市北区', page: 2 }
       response_symbolized_body => { offices:, paginate: }
       expect(paginate[:current_page]).to eq 2
       expect(offices.length).to eq 1
@@ -44,7 +44,7 @@ RSpec.describe 'Api::V1::Client::Offices' do
       Manager.second.update!(address: '広島県福山市南蔵王町4-1-7')
       Manager.third.update!(address: '千葉県浦安市富士見1-2-303')
       login client
-      get area_search_api_v1_client_offices_path, params: { q: '東京都新宿区市谷本村町,広島県福山市南蔵王町,千葉県浦安市富士見' }
+      get area_search_api_v1_client_offices_path, params: { areas: '東京都新宿区市谷本村町,広島県福山市南蔵王町,千葉県浦安市富士見' }
       expect(response.parsed_body['offices'].length).to eq 3
       assert_response_schema_confirm(200)
     end
@@ -70,7 +70,7 @@ RSpec.describe 'Api::V1::Client::Offices' do
 
     it '事業所一覧が返ってくること' do
       login client
-      get word_search_api_v1_client_offices_path, params: { q: 'ホームケア' }
+      get word_search_api_v1_client_offices_path, params: { words: 'ホームケア' }
       response_symbolized_body => { offices:, paginate: }
       expect(paginate[:current_page]).to eq 1
       expect(offices.length).to eq 3


### PR DESCRIPTION
## チケット
#101 

## やったこと
- 検索結果に総レコード数を含めるようにした
- エリア検索及び単語検索のクエリパラメータが共通で`q`だったが、区別がつけられるようにエリア検索を`areas`、単語検索を`words`に変更
