### PR TITLE
予約一覧取得(ケアマネ)

### DIFF
--- a/app/controllers/api/v1/manager/reserves_controller.rb
+++ b/app/controllers/api/v1/manager/reserves_controller.rb
@@ -3,6 +3,11 @@ module Api
     module Manager
       class ReservesController < ApplicationController
         before_action :authenticate_api_v1_manager!
+
+        def index
+          reserves = current_api_v1_manager.office.reserves
+          render json: reserves, status: :ok
+        end
       end
     end
   end

--- a/app/controllers/api/v1/manager/reserves_controller.rb
+++ b/app/controllers/api/v1/manager/reserves_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    module Manager
+      class ReservesController < ApplicationController
+        before_action :authenticate_api_v1_manager!
+      end
+    end
+  end
+end
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
         resources :office_images, only: [:create, :update]
         resources :staffs, only: [:index, :create, :update]
         resources :office_clients
+        resources :reserves, only: [:index]
       end
 
       namespace :client do

--- a/spec/requests/api/v1/manager/reserves_spec.rb
+++ b/spec/requests/api/v1/manager/reserves_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Manager::Reserves" do
+  describe "GET /api/v1/manager/reserves" do
+    let(:office) { create(:office) }
+    let(:manager) { create( office.manager) }
+    let(:client) { create(:client) }
+
+    it "事業所が、自身の予約一覧を取得できること" do
+      create_list(:reserve, 5, office:)
+      create_list(:reserve, 3)
+
+      login manager
+
+      get api_v1_manager_reserves_path
+      expect(response.parsed_body.length).to eq 5
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'ログインしていない場合、エラーが返ってくること' do
+      get api_v1_manager_reserves_path
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'クライアントでログインした場合、エラーが返ってくること' do
+      login client
+
+      get api_v1_manager_reserves_path
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/requests/api/v1/manager/reserves_spec.rb
+++ b/spec/requests/api/v1/manager/reserves_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Api::V1::Manager::Reserves" do
   describe "GET /api/v1/manager/reserves" do
     let(:office) { create(:office) }
-    let(:manager) { create( office.manager) }
+    let(:manager) { office.manager }
     let(:client) { create(:client) }
 
     it "事業所が、自身の予約一覧を取得できること" do


### PR DESCRIPTION
お疲れ様です！
予約一覧取得(ケアマネ)機能実装いたしました！
今issue見て気付いたのですが、エンドポイントは/api/v1/manager/reservesで問題ないでしょうか...
issueでは/api/v1/manager/appointments
OpenAPIでは/api/v1/manager/reserves
になっておりました。
問題あれば/api/v1/manager/appointmentsに変更いたします！

本来は実装前に確認すべきでした。すみません。

## チケット
https://github.com/rtkjm22/homeCareNavi_2nd_API/issues/63

## やったこと
GET /api/v1/manager/reserves作成

## できるようになること（ユーザ目線）
ケアマネが自身が所属する事務所に関する予約を取得できる

## OpenAPI
https://rahhi555.stoplight.io/docs/home-care-navi-second/f56ba2e2ae494-
![manager_fetch_reserves1](https://user-images.githubusercontent.com/85982768/207326673-0eb456fd-d4b1-4f9f-9520-dd2961eae743.PNG)
![manager_fetch_reserves2](https://user-images.githubusercontent.com/85982768/207326690-3782b784-e90f-4cb7-ac7b-55c4a3ccae7d.PNG)
