### PR TITLE
Manager update reserves

### DIFF
--- a/app/controllers/api/v1/manager/reserves_controller.rb
+++ b/app/controllers/api/v1/manager/reserves_controller.rb
@@ -8,6 +8,18 @@ module Api
           reserves = current_api_v1_manager.office.reserves
           render json: reserves, status: :ok
         end
+
+        def update
+          reserves = current_api_v1_manager.office.reserves
+          reserve_to_update = reserves.find(params[:id])
+
+          if reserve_to_update.update!(is_contacted: true)
+            render json: reserve_to_update, status: :ok
+          else
+            render json: reserve_to_update.as_error_json, status: :bad_request
+          end
+        end
+
       end
     end
   end

--- a/app/models/user/user.rb
+++ b/app/models/user/user.rb
@@ -3,8 +3,8 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable, :rememberable and :omniauthable
-  # devise :database_authenticatable, :registerable, :recoverable, :validatable, :confirmable
-  devise :database_authenticatable, :registerable, :recoverable, :validatable
+  devise :database_authenticatable, :registerable, :recoverable, :validatable, :confirmable
+
   include DeviseTokenAuth::Concerns::User
   include Discard::Model
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
         resources :office_images, only: [:create, :update]
         resources :staffs, only: [:index, :create, :update]
         resources :office_clients
-        resources :reserves, only: [:index]
+        resources :reserves, only: [:index, :update]
       end
 
       namespace :client do

--- a/spec/requests/api/v1/manager/reserves_spec.rb
+++ b/spec/requests/api/v1/manager/reserves_spec.rb
@@ -34,32 +34,24 @@ RSpec.describe "Api::V1::Manager::Reserves" do
     let(:office) { create(:office) }
     let(:manager) { office.manager }
     let(:client) { create(:client) }
-    let(:reserve) { office.reserve }
-    let!(:update_params) do
-      attrs = reserve.attributes
-      attrs['is_contacted'] = true
-      attrs
-    end
 
-    it "事業所は、自身の事業所のの予約を更新できる" do
+    it "事業所は、自身の事業所の予約を更新できる" do
+      reserve = create(:reserve, office:)
+
       login manager
-      expect do
-        patch api_v1_manager_reserve_path(reserve),
-              params: update_params,
-              headers: { ContentType: 'multipart/form-data' }
-        reserve.reload
-      end.to change(reserve, :is_contacted).to(true)
+
+      patch api_v1_manager_reserve_path(reserve)
+      expect(response).to have_http_status(200)
+      expect(reserve.reload.is_contacted).to eq true
     end
 
     it '事業所は、他の事業所の予約を更新ができない' do
-      another_reserve = create(:reserve)
-      update_params = another_reserve.attributes
-      update_params['is_contacted'] = true
+      reserve = create(:reserve)
+
       login manager
+
       expect do
-        patch api_v1_manager_reserve_path(another_reserve),
-              params: update_params,
-              headers: { ContentType: 'multipart/form-data' }
+        patch api_v1_manager_reserve_path(reserve)
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 


### PR DESCRIPTION
## チケット
https://github.com/rtkjm22/homeCareNavi_2nd_API/issues/64

## やったこと
事業所が予約テーブルのis_contactedカラムをfalseからtrueに更新できる

## できるようになること（ユーザ目線）
事業所が予約者と連絡が取れた場合、「予約者に連絡済み」に更新できる

## OpenAPI
https://rahhi555.stoplight.io/docs/home-care-navi-second/344060ab37879-
